### PR TITLE
Add English support across CLI, GUIs, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,35 @@
 # PPT2Fig
 
-PPT2Fig 用来把 PPT 页面导出成适合论文、汇报和文档插图使用的 PDF，并自动裁掉多余白边。
+PPT2Fig exports selected slides or pages from `ppt`, `pptx`, and `odp` files to PDF, then optionally crops excess whitespace so the result is ready for papers, reports, and figure-heavy documents.
 
-你可以把它当成：
+PPT2Fig 用来把 `ppt`、`pptx`、`odp` 中指定页面导出成 PDF，并可选自动裁掉多余白边，适合论文、汇报和文档插图场景。
 
-- Windows 下的当前页一键导出工具
-- 跨平台的 PPT 页面导出 CLI
-- 可被 OpenClaw / ClawHub 调用的导出 skill
+## Overview / 项目用途
 
-## 10 秒看懂
+- Export a single page, multiple pages, or page ranges from presentation files.
+- Support quick interactive export on desktop and scripted export in automation workflows.
+- Keep backend identifiers stable: `auto`, `libreoffice`, `wps`, `powerpoint`.
+- Provide both CLI and GUI entry points.
+- 支持单页、多页、页码范围导出。
+- 同时覆盖桌面交互导出和脚本/自动化导出。
+- 保持后端标识稳定：`auto`、`libreoffice`、`wps`、`powerpoint`。
+- 同时提供 CLI 和 GUI 入口。
 
-- 输入：`ppt` / `pptx` / `odp`
-- 输出：裁好白边的 PDF
-- 支持：单页、多页、页码范围
-- 可用方式：GUI、CLI、ClawHub skill
-- 后端：`LibreOffice`、`WPS`、`PowerPoint`
+## Backend Support / 后端支持
 
-## 主要特性
+Auto-selection currently prefers:
 
-- 适合论文作图、汇报插图、页面抽取
-- 自动裁剪白边，减少后处理
-- `auto` 模式自动选择可用后端
-- Windows 下保留“当前 PowerPoint 当前页”快速导出
-- 提供独立文件模式 GUI，适合重复导出
-- 提供跨平台 CLI，适合自动化
-- 可作为 OpenClaw / ClawHub skill 使用
-
-## 我该用哪种方式
-
-### 快速 GUI
-
-适合 Windows + PowerPoint，想要“改一页，导一页”。
-
-```bash
-ppt2fig
+```text
+LibreOffice > WPS > PowerPoint
 ```
 
-### 文件模式 GUI
+Supported platforms:
 
-适合需要指定文件路径、页码、输出路径、后端的人。
+- `LibreOffice`: Windows / Linux / macOS
+- `WPS`: Windows
+- `PowerPoint`: Windows for file-mode export, Windows/macOS for quick active-presentation export
 
-```bash
-ppt2fig-file-gui
-```
-
-### CLI / Skill
-
-适合脚本、批处理、自动化、AI 调用。
-
-```bash
-ppt2fig ./demo.pptx --pages 3
-```
-
-## 安装
-
-### Windows：直接下载 exe
-
-最简单：
-
-https://github.com/elliottzheng/ppt2fig/releases
-
-- `ppt2fig.exe`：快速 GUI
-- `ppt2fig-file-gui.exe`：文件模式 GUI
-- `ppt2fig-cli.exe`：CLI
-
-### Python：使用 pip
-
-```bash
-pip install ppt2fig
-```
-
-安装后可直接运行：
-
-```bash
-ppt2fig
-```
-
-### OpenClaw / ClawHub：安装 skill
-
-```bash
-clawhub install ppt2fig-export
-```
-安装后，AI 就可以直接调用 PPT2Fig，把指定演示文稿的指定页面导出成 PDF。需要搜索或更新时，可使用 `clawhub search ppt2fig` 和 `clawhub update ppt2fig-export`。
-
-## CLI 快速上手
-
-```bash
-ppt2fig ./demo.pptx --pages 3
-ppt2fig ./demo.pptx --pages 1,3,5-7 -o ./figure.pdf
-ppt2fig ./demo.pptx --pages 2 --no-crop
-ppt2fig ./demo.pptx --pages 2 --backend libreoffice
-ppt2fig ./demo.pptx --pages 2 --backend powerpoint --powerpoint-intent print
-ppt2fig --list-backends
-```
-
-查看版本可使用 `ppt2fig -v`。
-
-## 后端说明
-
-当前 `auto` 模式的优先级是：
+当前 `auto` 模式的优先级：
 
 ```text
 LibreOffice > WPS > PowerPoint
@@ -108,11 +39,106 @@ LibreOffice > WPS > PowerPoint
 
 - `LibreOffice`：Windows / Linux / macOS
 - `WPS`：Windows
-- `PowerPoint`：Windows
+- `PowerPoint`：文件模式导出支持 Windows，快速活动演示文稿导出支持 Windows/macOS
 
-如果你在 Linux/macOS 上使用 CLI，推荐安装 LibreOffice，并确保命令行里能找到 `soffice` 或 `libreoffice`。
+## Modes / 使用方式
 
-## 常用参数
+### Quick GUI / 快速 GUI
+
+Best when you already have PowerPoint open and want to export the current slide quickly.
+
+适合当前已经打开 PowerPoint，希望“改一页，导一页”。
+
+```bash
+ppt2fig
+```
+
+### File-Mode GUI / 文件模式 GUI
+
+Best when you want to choose the source file, pages, backend, and output path explicitly.
+
+适合手动指定文件路径、页码、后端和输出路径。
+
+```bash
+ppt2fig-file-gui
+```
+
+### CLI
+
+Best for scripts, batch jobs, and AI/tool integrations.
+
+适合脚本、批处理、自动化和 AI 调用。
+
+```bash
+ppt2fig ./demo.pptx --pages 3
+```
+
+## Installation / 安装
+
+### Windows executables / Windows 可执行文件
+
+Releases:
+
+https://github.com/elliottzheng/ppt2fig/releases
+
+- `ppt2fig.exe`: quick GUI
+- `ppt2fig-file-gui.exe`: file-mode GUI
+- `ppt2fig-cli.exe`: CLI
+- `ppt2fig.exe`：快速 GUI
+- `ppt2fig-file-gui.exe`：文件模式 GUI
+- `ppt2fig-cli.exe`：CLI
+
+### pip
+
+```bash
+pip install ppt2fig
+```
+
+After installation:
+
+安装后可直接运行：
+
+```bash
+ppt2fig
+```
+
+### OpenClaw / ClawHub skill
+
+```bash
+clawhub install ppt2fig-export
+```
+
+After installation, AI tools can invoke PPT2Fig directly to export selected pages from a presentation to PDF.
+
+安装后，AI 就可以直接调用 PPT2Fig，把指定演示文稿的指定页面导出成 PDF。
+
+## CLI Quick Start / CLI 快速上手
+
+```bash
+ppt2fig ./demo.pptx --pages 3
+ppt2fig ./demo.pptx --pages 1,3,5-7 -o ./figure.pdf
+ppt2fig ./demo.pptx --pages 2 --no-crop
+ppt2fig ./demo.pptx --pages 2 --backend libreoffice
+ppt2fig ./demo.pptx --pages 2 --backend powerpoint --powerpoint-intent print
+ppt2fig --list-backends
+ppt2fig --help --lang en
+```
+
+Useful flags:
+
+- `--pages`: required, supports `1,3,5-7`
+- `--output`: output PDF path
+- `--backend`: `auto` / `libreoffice` / `wps` / `powerpoint`
+- `--office-bin`: manually specify a backend executable path
+- `--no-crop`: skip whitespace cropping
+- `--percent-retain`: retain part of the original margin
+- `--margin-size`: add extra white margin after cropping
+- `--threshold`: background detection threshold
+- `--powerpoint-intent`: `print` or `screen`
+- `--bitmap-missing-fonts`: rasterize text if fonts cannot be embedded
+- `--lang`: `zh` or `en`, default `zh`
+
+常用参数：
 
 - `--pages`：必填，支持 `1,3,5-7`
 - `--output`：输出 PDF 路径
@@ -124,26 +150,33 @@ LibreOffice > WPS > PowerPoint
 - `--threshold`：背景检测阈值
 - `--powerpoint-intent`：`print` 或 `screen`
 - `--bitmap-missing-fonts`：字体无法嵌入时将文字转位图
+- `--lang`：`zh` 或 `en`，默认 `zh`
 
-## 注意事项
+## Notes / 注意事项
 
-- 快速 GUI 依赖当前打开的 PowerPoint
-- 文件模式 GUI 和 CLI 更适合跨平台与重复导出
-- CLI 通过先导出整份 PDF，再抽取指定页来工作
-- `--list-backends` 中的 `detected` 表示检测到候选程序，不一定表示当前平台已完整支持自动导出
-- PowerPoint 的 PDF 导出质量受其官方导出接口限制
+- The CLI exports the full PDF first and then extracts the selected pages.
+- `detected` in `--list-backends` means a candidate program was found, not necessarily that full automatic export is supported on the current platform.
+- PowerPoint export quality is limited by the official export interfaces it exposes.
+- CLI 先导出整份 PDF，再抽取指定页。
+- `--list-backends` 里的 `detected` 表示检测到候选程序，不一定代表当前平台已完整支持自动导出。
+- PowerPoint 的 PDF 导出质量受其官方导出接口限制。
 
-## 系统要求
+## Requirements / 系统要求
 
-- 快速 GUI：Windows + Microsoft PowerPoint
-- 文件模式 GUI / CLI：Windows / Linux / macOS，推荐 LibreOffice
-- Python：3.8+
+- Quick GUI: Windows/macOS with Microsoft PowerPoint available for the active-presentation workflow
+- File-mode GUI / CLI: Windows / Linux / macOS, with LibreOffice recommended for cross-platform use
+- Python: 3.6+
+- 快速 GUI：Windows/macOS，且活动演示文稿导出流程需要可用的 Microsoft PowerPoint
+- 文件模式 GUI / CLI：Windows / Linux / macOS，跨平台场景推荐安装 LibreOffice
+- Python：3.6+
 
-## 维护者文档
+## Maintainer Docs / 维护者文档
 
-- 编译指南见 `docs/BUILD.md`
-- ClawHub 发布指南见 `docs/CLAWHUB_PUBLISH.md`
+- Build guide: `docs/BUILD.md`
+- ClawHub publishing guide: `docs/CLAWHUB_PUBLISH.md`
+- 编译指南：`docs/BUILD.md`
+- ClawHub 发布指南：`docs/CLAWHUB_PUBLISH.md`
 
-## 许可证
+## License / 许可证
 
 [MIT License](LICENSE)

--- a/ppt2fig/cli.py
+++ b/ppt2fig/cli.py
@@ -3,12 +3,25 @@ from pathlib import Path
 
 from . import __version__
 from .core import detect_backends, export_selected_pages, parse_page_range
+from .i18n import DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, get_translator, install_argparse_translations
 
 
-def build_parser():
+def resolve_cli_language(argv=None):
+    args = list(argv or [])
+    for index, arg in enumerate(args):
+        if arg == "--lang" and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith("--lang="):
+            return arg.split("=", 1)[1]
+    return DEFAULT_LANGUAGE
+
+
+def build_parser(lang=DEFAULT_LANGUAGE):
+    install_argparse_translations(lang)
+    translator = get_translator(lang)
     parser = argparse.ArgumentParser(
         prog="ppt2fig",
-        description="将指定 PPTX 的指定页导出为 PDF，并可选自动裁剪白边。",
+        description=translator("cli.description"),
     )
     parser.add_argument(
         "-v",
@@ -16,71 +29,77 @@ def build_parser():
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    parser.add_argument("pptx", nargs="?", help="输入的 PPTX 文件路径")
+    parser.add_argument(
+        "--lang",
+        choices=SUPPORTED_LANGUAGES,
+        default=DEFAULT_LANGUAGE,
+        help=translator("lang.help"),
+    )
+    parser.add_argument("pptx", nargs="?", help=translator("cli.arg.pptx"))
     parser.add_argument(
         "-p",
         "--pages",
-        help="要导出的页码，支持 1,3,5-7 这种格式，页码从 1 开始",
+        help=translator("cli.arg.pages"),
     )
     parser.add_argument(
         "-o",
         "--output",
-        help="输出 PDF 路径，默认在输入文件同目录下生成",
+        help=translator("cli.arg.output"),
     )
     parser.add_argument(
         "--office-bin",
-        help="手动指定导出后端可执行文件路径，例如 soffice 或 libreoffice",
+        help=translator("cli.arg.office_bin"),
     )
     parser.add_argument(
         "--backend",
         choices=["auto", "libreoffice", "powerpoint", "wps"],
         default="auto",
-        help="选择导出后端，默认 auto",
+        help=translator("cli.arg.backend"),
     )
     parser.add_argument(
         "--list-backends",
         action="store_true",
-        help="列出当前系统检测到的候选后端并退出",
+        help=translator("cli.arg.list_backends"),
     )
     parser.add_argument(
         "--powerpoint-intent",
         choices=["print", "screen"],
         default="print",
-        help="PowerPoint 后端的导出意图，默认 print",
+        help=translator("cli.arg.powerpoint_intent"),
     )
     parser.add_argument(
         "--bitmap-missing-fonts",
         action="store_true",
-        help="PowerPoint 后端在字体无法嵌入时将文字位图化",
+        help=translator("cli.arg.bitmap_missing_fonts"),
     )
-    parser.add_argument("--no-crop", action="store_true", help="导出后不裁剪白边")
+    parser.add_argument("--no-crop", action="store_true", help=translator("cli.arg.no_crop"))
     parser.add_argument(
         "--percent-retain",
         type=float,
         default=0.0,
-        help="保留原始边距的百分比，默认 0",
+        help=translator("cli.arg.percent_retain"),
     )
     parser.add_argument(
         "--margin-size",
         type=float,
         default=0.0,
-        help="裁剪后额外增加的白边，单位 bp，默认 0",
+        help=translator("cli.arg.margin_size"),
     )
     parser.add_argument(
         "--threshold",
         type=int,
         default=191,
-        help="背景检测阈值，默认 191",
+        help=translator("cli.arg.threshold"),
     )
     parser.add_argument(
         "--no-uniform",
         action="store_true",
-        help="禁用统一裁剪",
+        help=translator("cli.arg.no_uniform"),
     )
     parser.add_argument(
         "--no-same-size",
         action="store_true",
-        help="禁用统一页面大小",
+        help=translator("cli.arg.no_same_size"),
     )
     return parser
 
@@ -92,48 +111,62 @@ def default_output_path(pptx_path, pages):
 
 
 def main(argv=None):
-    parser = build_parser()
+    cli_lang = resolve_cli_language(argv)
+    parser = build_parser(cli_lang)
     args = parser.parse_args(argv)
+    translator = get_translator(args.lang)
 
     if args.list_backends:
-        backends = detect_backends(explicit_path=args.office_bin)
+        backends = detect_backends(explicit_path=args.office_bin, lang=args.lang)
         if not backends:
-            print("未检测到任何候选后端")
+            print(translator("cli.list_backends.none"))
             return
         for backend in backends:
-            status = "supported" if backend.supported else "detected"
+            status = (
+                translator("cli.backend.supported")
+                if backend.supported
+                else translator("cli.backend.detected")
+            )
             suffix = f" ({backend.detail})" if backend.detail else ""
             print(f"{backend.name}\t{status}\t{backend.path}{suffix}")
         return
 
     if not args.pptx:
-        parser.error("缺少输入文件 pptx")
+        parser.error(translator("cli.error.missing_pptx"))
     if not args.pages:
-        parser.error("missing required argument: -p/--pages")
+        parser.error(translator("cli.error.missing_pages"))
 
-    pages = parse_page_range(args.pages)
+    try:
+        pages = parse_page_range(args.pages, lang=args.lang)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     source = Path(args.pptx).resolve()
     if not source.exists():
-        parser.error(f"输入文件不存在: {source}")
+        parser.error(translator("cli.error.input_not_found", path=source))
     if source.suffix.lower() not in {".pptx", ".ppt", ".odp"}:
-        parser.error("输入文件必须是 .pptx、.ppt 或 .odp")
+        parser.error(translator("cli.error.invalid_extension"))
 
     output = Path(args.output).resolve() if args.output else default_output_path(source, pages)
-    export_selected_pages(
-        source,
-        output,
-        pages,
-        backend=args.backend,
-        office_bin=args.office_bin,
-        powerpoint_intent=args.powerpoint_intent,
-        bitmap_missing_fonts=args.bitmap_missing_fonts,
-        no_crop=args.no_crop,
-        percent_retain=args.percent_retain,
-        margin_size=args.margin_size,
-        use_uniform=not args.no_uniform,
-        use_same_size=not args.no_same_size,
-        threshold=args.threshold,
-    )
+    try:
+        export_selected_pages(
+            source,
+            output,
+            pages,
+            lang=args.lang,
+            backend=args.backend,
+            office_bin=args.office_bin,
+            powerpoint_intent=args.powerpoint_intent,
+            bitmap_missing_fonts=args.bitmap_missing_fonts,
+            no_crop=args.no_crop,
+            percent_retain=args.percent_retain,
+            margin_size=args.margin_size,
+            use_uniform=not args.no_uniform,
+            use_same_size=not args.no_same_size,
+            threshold=args.threshold,
+        )
+    except Exception as exc:
+        parser.exit(1, f"{parser.prog}: {translator('cli.error.prefix')}: {exc}\n")
     print(output)
 
 

--- a/ppt2fig/core.py
+++ b/ppt2fig/core.py
@@ -3,8 +3,10 @@ import platform
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
+
+from .i18n import DEFAULT_LANGUAGE, get_translator
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,8 @@ class BackendInfo:
 
 
 SYSTEM_NAME = platform.system()
+POWERPOINT_NOT_RUNNING = "__PPT2FIG_POWERPOINT_NOT_RUNNING__"
+POWERPOINT_NO_PRESENTATION = "__PPT2FIG_NO_PRESENTATION__"
 
 
 def build_crop_args(
@@ -45,6 +49,7 @@ def build_crop_args(
 def crop_pdf_file(
     pdf_file,
     *,
+    lang=DEFAULT_LANGUAGE,
     no_crop=False,
     percent_retain=0.0,
     margin_size=0.0,
@@ -58,7 +63,7 @@ def crop_pdf_file(
     try:
         from pdfCropMargins import crop
     except ImportError as exc:
-        raise RuntimeError("当前环境缺少 pdfCropMargins，无法执行 PDF 裁剪") from exc
+        raise RuntimeError(get_translator(lang)("core.error.missing_pdfcropmargins")) from exc
 
     pdf_path = Path(pdf_file)
     tmp_output = pdf_path.with_suffix(pdf_path.suffix + ".crop")
@@ -76,9 +81,10 @@ def crop_pdf_file(
     shutil.move(str(tmp_output), str(pdf_path))
 
 
-def parse_page_range(page_spec):
+def parse_page_range(page_spec, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     if not page_spec:
-        raise ValueError("页码不能为空")
+        raise ValueError(translator("core.error.page_empty"))
 
     pages = []
     for raw_part in page_spec.split(","):
@@ -87,21 +93,27 @@ def parse_page_range(page_spec):
             continue
         if "-" in part:
             start_text, end_text = part.split("-", 1)
-            start = int(start_text)
-            end = int(end_text)
+            try:
+                start = int(start_text)
+                end = int(end_text)
+            except ValueError as exc:
+                raise ValueError(translator("core.error.invalid_page_range", part=part)) from exc
             if start <= 0 or end <= 0:
-                raise ValueError("页码必须从 1 开始")
+                raise ValueError(translator("core.error.page_must_start_1"))
             if end < start:
-                raise ValueError(f"无效页码范围: {part}")
+                raise ValueError(translator("core.error.invalid_page_range", part=part))
             pages.extend(range(start, end + 1))
         else:
-            page = int(part)
+            try:
+                page = int(part)
+            except ValueError as exc:
+                raise ValueError(translator("core.error.invalid_page_token", value=part)) from exc
             if page <= 0:
-                raise ValueError("页码必须从 1 开始")
+                raise ValueError(translator("core.error.page_must_start_1"))
             pages.append(page)
 
     if not pages:
-        raise ValueError("没有解析出有效页码")
+        raise ValueError(translator("core.error.no_valid_pages"))
 
     deduplicated = []
     seen = set()
@@ -112,11 +124,12 @@ def parse_page_range(page_spec):
     return deduplicated
 
 
-def extract_pdf_pages(input_pdf, output_pdf, pages):
+def extract_pdf_pages(input_pdf, output_pdf, pages, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     try:
         from pypdf import PdfReader, PdfWriter
     except ImportError as exc:
-        raise RuntimeError("当前环境缺少 pypdf，无法抽取指定页") from exc
+        raise RuntimeError(translator("core.error.missing_pypdf")) from exc
 
     reader = PdfReader(str(input_pdf))
     writer = PdfWriter()
@@ -125,7 +138,11 @@ def extract_pdf_pages(input_pdf, output_pdf, pages):
     for page_number in pages:
         if page_number > total_pages:
             raise ValueError(
-                f"请求的页码 {page_number} 超出范围，导出的 PDF 只有 {total_pages} 页"
+                translator(
+                    "core.error.page_out_of_range",
+                    page_number=page_number,
+                    total_pages=total_pages,
+                )
             )
         writer.add_page(reader.pages[page_number - 1])
 
@@ -245,27 +262,28 @@ def _find_windows_app_path(*exe_names):
     return None
 
 
-def _can_use_powerpoint_com():
+def _can_use_powerpoint_com(*, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     if SYSTEM_NAME == "Windows":
         try:
             import comtypes.client  # noqa: F401
         except ImportError:
-            return False, "当前环境缺少 comtypes"
+            return False, translator("core.detail.missing_comtypes")
 
         try:
             app = comtypes.client.CreateObject("Powerpoint.Application")
             app.Quit()
             return True, ""
         except Exception as exc:
-            return False, f"COM 不可用: {exc}"
+            return False, translator("core.detail.com_unavailable", error=exc)
 
     if SYSTEM_NAME == "Darwin":
         app_path = _find_powerpoint_executable()
         if not app_path:
-            return False, "未检测到 Microsoft PowerPoint.app"
-        return True, "可通过 AppleScript 驱动"
+            return False, translator("core.detail.powerpoint_not_detected_mac")
+        return True, translator("core.detail.powerpoint_applescript")
 
-    return False, "当前系统不支持 PowerPoint CLI 导出"
+    return False, translator("core.detail.powerpoint_cli_not_supported")
 
 
 def _find_wps_com_progid():
@@ -290,20 +308,21 @@ def _find_wps_com_progid():
     return None
 
 
-def _can_use_wps_com(has_wps_binary=False):
+def _can_use_wps_com(has_wps_binary=False, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     if SYSTEM_NAME == "Windows":
         try:
             import comtypes.client  # noqa: F401
         except ImportError:
-            return False, "当前环境缺少 comtypes"
+            return False, translator("core.detail.missing_comtypes")
 
         if not has_wps_binary:
-            return False, "未检测到 WPS 可执行文件"
+            return False, translator("core.detail.wps_binary_not_detected")
 
         progid = _find_wps_com_progid()
         if progid:
-            return True, f"COM 可用: {progid}"
-        return False, "未找到 WPS Presentation COM ProgID"
+            return True, translator("core.detail.com_available", value=progid)
+        return False, translator("core.detail.wps_com_progid_not_found")
 
     if SYSTEM_NAME == "Darwin":
         candidates = [
@@ -313,15 +332,16 @@ def _can_use_wps_com(has_wps_binary=False):
         ]
         for candidate in candidates:
             if os.path.exists(candidate):
-                return False, "已检测到 WPS.app，但当前还未实现 macOS 自动导出"
-        return False, "未检测到 WPS.app"
+                return False, translator("core.detail.wps_mac_not_implemented")
+        return False, translator("core.detail.wps_app_not_detected")
 
     if has_wps_binary:
-        return False, "已检测到 WPS 可执行文件，但当前还未实现该平台自动导出"
-    return False, "未检测到 WPS 可执行文件"
+        return False, translator("core.detail.wps_platform_not_implemented")
+    return False, translator("core.detail.wps_binary_not_detected")
 
 
-def detect_backends(explicit_path=None):
+def detect_backends(explicit_path=None, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     backends = []
     seen_paths = set()
     has_wps_binary = False
@@ -364,13 +384,13 @@ def detect_backends(explicit_path=None):
         detail = ""
         if backend_name == "wps":
             supported = False
-            detail = "已检测到 WPS 候选程序"
+            detail = translator("core.detail.wps_candidate_detected")
         elif backend_name == "custom":
-            detail = "通过 --office-bin 指定"
+            detail = translator("core.detail.explicit_office_bin")
         elif backend_name == "powerpoint":
-            detail = "已检测到 PowerPoint 候选程序"
+            detail = translator("core.detail.powerpoint_candidate_detected")
         elif explicit_path and os.path.abspath(resolved) == os.path.abspath(explicit_path):
-            detail = "通过 --office-bin 指定"
+            detail = translator("core.detail.explicit_office_bin")
 
         backends.append(
             BackendInfo(
@@ -383,7 +403,7 @@ def detect_backends(explicit_path=None):
         )
 
     if has_wps_binary:
-        supported, detail = _can_use_wps_com(has_wps_binary=True)
+        supported, detail = _can_use_wps_com(has_wps_binary=True, lang=lang)
         for index, item in enumerate(backends):
             if item.name == "wps":
                 backends[index] = BackendInfo(
@@ -398,7 +418,7 @@ def detect_backends(explicit_path=None):
     if powerpoint_executable:
         normalized = os.path.normcase(os.path.abspath(powerpoint_executable))
         if normalized not in seen_paths:
-            supported, detail = _can_use_powerpoint_com()
+            supported, detail = _can_use_powerpoint_com(lang=lang)
             backends.append(
                 BackendInfo(
                     name="powerpoint",
@@ -413,8 +433,9 @@ def detect_backends(explicit_path=None):
     return backends
 
 
-def find_backend(explicit_path=None, backend="auto"):
-    detected = detect_backends(explicit_path=explicit_path)
+def find_backend(explicit_path=None, backend="auto", *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
+    detected = detect_backends(explicit_path=explicit_path, lang=lang)
     if backend == "auto":
         preferred_order = ["libreoffice", "wps", "powerpoint", "custom"]
     else:
@@ -425,16 +446,25 @@ def find_backend(explicit_path=None, backend="auto"):
             if item.name == preferred_name and item.supported:
                 return item
 
-    detected_names = ", ".join(f"{item.name}:{item.path}" for item in detected) or "无"
+    detected_names = ", ".join(f"{item.name}:{item.path}" for item in detected) or (
+        "无" if lang == "zh" else "none"
+    )
     raise FileNotFoundError(
-        f"未找到可用的导出后端。请求后端: {backend}。"
-        f" 已检测到: {detected_names}。"
-        " 当前已实现的自动导出后端: LibreOffice、PowerPoint(Windows/macOS)、WPS(Windows)。"
+        translator(
+            "core.error.backend_not_found",
+            backend=backend,
+            detected_names=detected_names,
+        )
     )
 
 
-def export_pptx_to_pdf_with_libreoffice(pptx_path, output_pdf, office_bin=None):
-    office_executable = find_backend(explicit_path=office_bin, backend="libreoffice").path
+def export_pptx_to_pdf_with_libreoffice(pptx_path, output_pdf, office_bin=None, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
+    office_executable = find_backend(
+        explicit_path=office_bin,
+        backend="libreoffice",
+        lang=lang,
+    ).path
     source_path = Path(pptx_path).resolve()
     output_path = Path(output_pdf).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -453,12 +483,12 @@ def export_pptx_to_pdf_with_libreoffice(pptx_path, output_pdf, office_bin=None):
         if result.returncode != 0:
             stderr = result.stderr.strip()
             stdout = result.stdout.strip()
-            details = stderr or stdout or "LibreOffice 导出失败"
+            details = stderr or stdout or translator("core.error.libreoffice_export_failed_default")
             raise RuntimeError(details)
 
         converted_pdf = Path(tmp_dir) / f"{source_path.stem}.pdf"
         if not converted_pdf.exists():
-            raise RuntimeError("LibreOffice 没有生成预期的 PDF 文件")
+            raise RuntimeError(translator("core.error.libreoffice_pdf_missing"))
 
         shutil.copyfile(str(converted_pdf), str(output_path))
     return output_path
@@ -468,16 +498,18 @@ def export_pptx_to_pdf_with_powerpoint(
     pptx_path,
     output_pdf,
     *,
+    lang=DEFAULT_LANGUAGE,
     intent="print",
     bitmap_missing_fonts=False,
 ):
+    translator = get_translator(lang)
     if platform.system() != "Windows":
-        raise RuntimeError("PowerPoint 后端仅支持 Windows")
+        raise RuntimeError(translator("core.error.powerpoint_windows_only"))
 
     try:
         import comtypes.client
     except ImportError as exc:
-        raise RuntimeError("当前环境缺少 comtypes，无法调用 PowerPoint") from exc
+        raise RuntimeError(translator("core.error.missing_comtypes_powerpoint")) from exc
 
     source_path = Path(pptx_path).resolve()
     output_path = Path(output_pdf).resolve()
@@ -504,7 +536,7 @@ def export_pptx_to_pdf_with_powerpoint(
             UseISO19005_1=False,
         )
     except Exception as exc:
-        raise RuntimeError(f"PowerPoint 导出失败: {exc}") from exc
+        raise RuntimeError(translator("core.error.powerpoint_export_failed", error=exc)) from exc
     finally:
         if presentation is not None:
             try:
@@ -518,22 +550,23 @@ def export_pptx_to_pdf_with_powerpoint(
                 pass
 
     if not output_path.exists():
-        raise RuntimeError("PowerPoint 没有生成预期的 PDF 文件")
+        raise RuntimeError(translator("core.error.powerpoint_pdf_missing"))
     return output_path
 
 
-def export_pptx_to_pdf_with_wps(pptx_path, output_pdf):
+def export_pptx_to_pdf_with_wps(pptx_path, output_pdf, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     if platform.system() != "Windows":
-        raise RuntimeError("WPS 后端仅支持 Windows")
+        raise RuntimeError(translator("core.error.wps_windows_only"))
 
     try:
         import comtypes.client
     except ImportError as exc:
-        raise RuntimeError("当前环境缺少 comtypes，无法调用 WPS") from exc
+        raise RuntimeError(translator("core.error.missing_comtypes_wps")) from exc
 
     progid = _find_wps_com_progid()
     if not progid:
-        raise RuntimeError("未找到可用的 WPS Presentation COM 接口")
+        raise RuntimeError(translator("core.error.wps_com_missing"))
 
     source_path = Path(pptx_path).resolve()
     output_path = Path(output_pdf).resolve()
@@ -566,12 +599,16 @@ def export_pptx_to_pdf_with_wps(pptx_path, output_pdf):
                 presentation.SaveAs(str(output_path), 32)
             except Exception as exc:
                 raise RuntimeError(
-                    f"WPS 导出失败。ExportAsFixedFormat 错误: {export_error}; SaveAs(PDF) 错误: {exc}"
+                    translator(
+                        "core.error.wps_export_failed_both",
+                        fixed_error=export_error,
+                        save_error=exc,
+                    )
                 ) from exc
     except Exception as exc:
         if isinstance(exc, RuntimeError):
             raise
-        raise RuntimeError(f"WPS 导出失败: {exc}") from exc
+        raise RuntimeError(translator("core.error.wps_export_failed", error=exc)) from exc
     finally:
         if presentation is not None:
             try:
@@ -585,7 +622,7 @@ def export_pptx_to_pdf_with_wps(pptx_path, output_pdf):
                 pass
 
     if not output_path.exists():
-        raise RuntimeError("WPS 没有生成预期的 PDF 文件")
+        raise RuntimeError(translator("core.error.wps_pdf_missing"))
     return output_path
 
 
@@ -594,6 +631,7 @@ def export_selected_pages(
     output_pdf,
     pages,
     *,
+    lang=DEFAULT_LANGUAGE,
     backend="auto",
     office_bin=None,
     powerpoint_intent="print",
@@ -610,23 +648,30 @@ def export_selected_pages(
 
     with tempfile.TemporaryDirectory(prefix="ppt2fig-pages-") as tmp_dir:
         full_pdf = Path(tmp_dir) / "full.pdf"
-        selected_backend = find_backend(explicit_path=office_bin, backend=backend)
+        selected_backend = find_backend(explicit_path=office_bin, backend=backend, lang=lang)
         if selected_backend.name in {"libreoffice", "custom"}:
-            export_pptx_to_pdf_with_libreoffice(pptx_path, full_pdf, office_bin=selected_backend.path)
+            export_pptx_to_pdf_with_libreoffice(
+                pptx_path,
+                full_pdf,
+                office_bin=selected_backend.path,
+                lang=lang,
+            )
         elif selected_backend.name == "powerpoint":
             export_pptx_to_pdf_with_powerpoint(
                 pptx_path,
                 full_pdf,
+                lang=lang,
                 intent=powerpoint_intent,
                 bitmap_missing_fonts=bitmap_missing_fonts,
             )
         elif selected_backend.name == "wps":
-            export_pptx_to_pdf_with_wps(pptx_path, full_pdf)
+            export_pptx_to_pdf_with_wps(pptx_path, full_pdf, lang=lang)
         else:
-            raise RuntimeError(f"暂不支持使用后端 {selected_backend.name} 导出")
-        extract_pdf_pages(full_pdf, output_path, pages)
+            raise RuntimeError(get_translator(lang)("core.error.backend_unsupported", backend=selected_backend.name))
+        extract_pdf_pages(full_pdf, output_path, pages, lang=lang)
         crop_pdf_file(
             output_path,
+            lang=lang,
             no_crop=no_crop,
             percent_retain=percent_retain,
             margin_size=margin_size,
@@ -637,11 +682,12 @@ def export_selected_pages(
     return output_path
 
 
-def current_slide_2_pdf_windows(output_pdf_file):
+def current_slide_2_pdf_windows(output_pdf_file, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     try:
         import comtypes.client
     except ImportError as exc:
-        raise RuntimeError("当前环境缺少 comtypes，无法调用 PowerPoint") from exc
+        raise RuntimeError(translator("core.error.missing_comtypes_powerpoint")) from exc
 
     powerpoint = comtypes.client.CreateObject("Powerpoint.Application")
     powerpoint.Visible = 1
@@ -653,15 +699,16 @@ def current_slide_2_pdf_windows(output_pdf_file):
     return True
 
 
-def current_slide_2_pdf_mac(output_pdf_file):
+def current_slide_2_pdf_mac(output_pdf_file, *, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     script = '''
     tell application "Microsoft PowerPoint"
         if not running then
-            return "PowerPoint未启动"
+            return "%s"
         end if
 
         if (count of presentations) is 0 then
-            return "没有打开的PPT文件"
+            return "%s"
         end if
 
         set pdfPath to "%s"
@@ -669,15 +716,21 @@ def current_slide_2_pdf_mac(output_pdf_file):
         save active presentation in pdfPath as save as PDF
         return "success"
     end tell
-    ''' % output_pdf_file
+    ''' % (POWERPOINT_NOT_RUNNING, POWERPOINT_NO_PRESENTATION, output_pdf_file)
 
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
     if "success" in result.stdout:
         return True
-    raise RuntimeError(result.stdout.strip() or result.stderr.strip() or "转换过程出错")
+    stdout = result.stdout.strip()
+    if stdout == POWERPOINT_NOT_RUNNING:
+        raise RuntimeError(translator("core.error.active_powerpoint_not_running"))
+    if stdout == POWERPOINT_NO_PRESENTATION:
+        raise RuntimeError(translator("core.error.active_powerpoint_no_file"))
+    raise RuntimeError(stdout or result.stderr.strip() or translator("core.error.conversion_failed"))
 
 
-def get_active_presentation_info():
+def get_active_presentation_info(*, lang=DEFAULT_LANGUAGE):
+    translator = get_translator(lang)
     if platform.system() == "Windows":
         import comtypes.client
 
@@ -686,27 +739,30 @@ def get_active_presentation_info():
             ppt_file = powerpoint.ActivePresentation
             return ppt_file.FullName, ppt_file.Name
         except Exception as exc:
-            raise RuntimeError("PowerPoint未启动或没有打开的文件") from exc
+            raise RuntimeError(translator("core.error.active_presentation_missing")) from exc
 
     script = '''
     tell application "Microsoft PowerPoint"
         if not running then
-            return "PowerPoint未启动"
+            return "%s"
         end if
 
         if (count of presentations) is 0 then
-            return "没有打开的PPT文件"
+            return "%s"
         end if
 
         set thePresentation to active presentation
         return {full name of thePresentation, name of thePresentation}
     end tell
-    '''
+    ''' % (POWERPOINT_NOT_RUNNING, POWERPOINT_NO_PRESENTATION)
     result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
-    if "PowerPoint未启动" in result.stdout or "没有打开的PPT文件" in result.stdout:
-        raise RuntimeError(result.stdout.strip())
+    stdout = result.stdout.strip()
+    if stdout == POWERPOINT_NOT_RUNNING:
+        raise RuntimeError(translator("core.error.active_powerpoint_not_running"))
+    if stdout == POWERPOINT_NO_PRESENTATION:
+        raise RuntimeError(translator("core.error.active_powerpoint_no_file"))
 
-    output = result.stdout.strip().split(", ")
+    output = stdout.split(", ")
     if len(output) == 2:
         return output[0], output[1]
-    raise RuntimeError("无法获取PPT文件信息")
+    raise RuntimeError(translator("core.error.active_presentation_info_failed"))

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -367,9 +367,11 @@ def main():
     footer = ttk.Frame(form_panel)
     footer.pack(fill=tk.X, pady=(12, 0))
     ttk.Label(footer, textvariable=status_var, foreground="#444444", justify=tk.LEFT, wraplength=860).pack(
-        side=tk.LEFT, fill=tk.X, expand=True
+        fill=tk.X, expand=True, anchor="w"
     )
-    export_button = ttk.Button(footer)
+    footer_actions = ttk.Frame(footer)
+    footer_actions.pack(fill=tk.X, pady=(10, 0))
+    export_button = ttk.Button(footer_actions)
     export_button.pack(side=tk.RIGHT)
 
     def refresh_history_list(select_index=None):

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -38,6 +38,12 @@ def _fit_window(root, *, min_width, min_height, width_padding=48, height_padding
     root.minsize(width, height)
 
 
+def _file_gui_min_size(lang):
+    if lang == "en":
+        return 1280, 920
+    return 1120, 820
+
+
 def _load_file_mode_history():
     try:
         if not FILE_MODE_HISTORY_PATH.exists():
@@ -124,8 +130,9 @@ def _make_output_path(source_text, pages_text, *, lang=DEFAULT_LANGUAGE):
 def main():
     _enable_high_dpi_support()
     root = tk.Tk()
-    root.geometry("1120x820")
-    root.minsize(1120, 820)
+    initial_width, initial_height = _file_gui_min_size(DEFAULT_LANGUAGE)
+    root.geometry(f"{initial_width}x{initial_height}")
+    root.minsize(initial_width, initial_height)
 
     source_var = tk.StringVar()
     pages_var = tk.StringVar(value="1")
@@ -189,7 +196,7 @@ def main():
     )
     language_select.pack(side=tk.LEFT, padx=(8, 0))
 
-    subtitle_label = ttk.Label(header, foreground="#555555", wraplength=920, justify=tk.LEFT)
+    subtitle_label = ttk.Label(header, foreground="#555555", wraplength=1080, justify=tk.LEFT)
     subtitle_label.pack(anchor="w", pady=(6, 0))
 
     body = ttk.PanedWindow(outer, orient=tk.HORIZONTAL)
@@ -202,7 +209,7 @@ def main():
 
     history_title_label = ttk.Label(history_panel, font=("Microsoft YaHei UI", 11, "bold"))
     history_title_label.pack(anchor="w")
-    history_subtitle_label = ttk.Label(history_panel, foreground="#666666", wraplength=250, justify=tk.LEFT)
+    history_subtitle_label = ttk.Label(history_panel, foreground="#666666", wraplength=320, justify=tk.LEFT)
     history_subtitle_label.pack(anchor="w", pady=(2, 8))
 
     history_list = tk.Listbox(history_panel, activestyle="none", height=18)
@@ -359,7 +366,7 @@ def main():
 
     footer = ttk.Frame(form_panel)
     footer.pack(fill=tk.X, pady=(12, 0))
-    ttk.Label(footer, textvariable=status_var, foreground="#444444", justify=tk.LEFT, wraplength=650).pack(
+    ttk.Label(footer, textvariable=status_var, foreground="#444444", justify=tk.LEFT, wraplength=860).pack(
         side=tk.LEFT, fill=tk.X, expand=True
     )
     export_button = ttk.Button(footer)
@@ -609,6 +616,7 @@ def main():
 
     def update_texts():
         current = translator()
+        min_width, min_height = _file_gui_min_size(language_var.get())
         root.title(current("gui.file.title", version=__version__))
         language_label.config(text=current("lang.label"))
         title_label.config(text=current("gui.file.header_title"))
@@ -655,6 +663,7 @@ def main():
         refresh_history_list(selected_history_index["value"])
         refresh_backends(verbose=False)
         status_var.set(current(status_state["key"], **status_state["kwargs"]))
+        _fit_window(root, min_width=min_width, min_height=min_height, width_padding=72, height_padding=72)
 
     load_button.config(command=lambda: apply_history_item(get_selected_history_item()))
     rerun_button.config(command=lambda: start_export(from_history=True))
@@ -685,7 +694,7 @@ def main():
     set_status("gui.file.status.ready")
     update_dynamic_state()
     update_texts()
-    _fit_window(root, min_width=1120, min_height=820)
+    _fit_window(root, min_width=initial_width, min_height=initial_height, width_padding=72, height_padding=72)
     root.mainloop()
 
 

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -475,7 +475,7 @@ def main():
             except Exception:
                 pass
 
-    def validate_form():
+    def collect_export_settings():
         current = translator()
         source = source_var.get().strip()
         if not source:
@@ -483,67 +483,85 @@ def main():
         path = Path(source).resolve()
         if not path.exists():
             raise ValueError(current("gui.file.error.input_not_found"))
-        pages = parse_page_range(pages_var.get().strip(), lang=language_var.get())
+        pages_text = pages_var.get().strip()
+        lang = language_var.get()
+        pages = parse_page_range(pages_text, lang=lang)
         output = output_var.get().strip()
         if not output:
-            output = _make_output_path(source, pages_var.get().strip(), lang=language_var.get())
+            output = _make_output_path(source, pages_text, lang=lang)
             output_var.set(output)
-        return path, pages, output
+        return {
+            "source": path,
+            "source_text": source,
+            "pages": pages,
+            "pages_text": pages_text,
+            "output": output,
+            "backend": backend_var.get(),
+            "office_bin": office_bin_var.get().strip() or None,
+            "powerpoint_intent": powerpoint_intent_var.get(),
+            "bitmap_missing_fonts": bitmap_missing_fonts_var.get(),
+            "no_crop": no_crop_var.get(),
+            "percent_retain": percent_retain_var.get(),
+            "margin_size": margin_size_var.get(),
+            "use_uniform": use_uniform_var.get(),
+            "use_same_size": use_same_size_var.get(),
+            "threshold": threshold_var.get(),
+            "lang": lang,
+        }
 
-    def on_export_success():
+    def on_export_success(settings):
         history_items[:] = _record_current_settings(
             history_items,
-            source=source_var.get(),
-            pages=pages_var.get(),
-            output=output_var.get(),
-            backend=backend_var.get(),
-            office_bin=office_bin_var.get(),
-            powerpoint_intent=powerpoint_intent_var.get(),
-            bitmap_missing_fonts=bitmap_missing_fonts_var.get(),
-            no_crop=no_crop_var.get(),
-            percent_retain=percent_retain_var.get(),
-            margin_size=margin_size_var.get(),
-            use_uniform=use_uniform_var.get(),
-            use_same_size=use_same_size_var.get(),
-            threshold=threshold_var.get(),
+            source=settings["source_text"],
+            pages=settings["pages_text"],
+            output=settings["output"],
+            backend=settings["backend"],
+            office_bin=settings["office_bin"] or "",
+            powerpoint_intent=settings["powerpoint_intent"],
+            bitmap_missing_fonts=settings["bitmap_missing_fonts"],
+            no_crop=settings["no_crop"],
+            percent_retain=settings["percent_retain"],
+            margin_size=settings["margin_size"],
+            use_uniform=settings["use_uniform"],
+            use_same_size=settings["use_same_size"],
+            threshold=settings["threshold"],
         )
         _save_file_mode_history(history_items)
         refresh_history_list(0)
-        set_status("gui.file.status.export_done", path=output_var.get())
+        set_status("gui.file.status.export_done", path=settings["output"])
         exporting["active"] = False
         export_button.configure(state=tk.NORMAL)
         current = translator()
         messagebox.showinfo(
             current("common.success"),
-            current("gui.quick.success_message", path=output_var.get()),
+            current("gui.quick.success_message", path=settings["output"]),
             parent=root,
         )
 
-    def run_export():
+    def run_export(settings):
         try:
-            source, pages, output = validate_form()
             export_selected_pages(
-                source,
-                output,
-                pages,
-                lang=language_var.get(),
-                backend=backend_var.get(),
-                office_bin=office_bin_var.get().strip() or None,
-                powerpoint_intent=powerpoint_intent_var.get(),
-                bitmap_missing_fonts=bitmap_missing_fonts_var.get(),
-                no_crop=no_crop_var.get(),
-                percent_retain=percent_retain_var.get(),
-                margin_size=margin_size_var.get(),
-                use_uniform=use_uniform_var.get(),
-                use_same_size=use_same_size_var.get(),
-                threshold=threshold_var.get(),
+                settings["source"],
+                settings["output"],
+                settings["pages"],
+                lang=settings["lang"],
+                backend=settings["backend"],
+                office_bin=settings["office_bin"],
+                powerpoint_intent=settings["powerpoint_intent"],
+                bitmap_missing_fonts=settings["bitmap_missing_fonts"],
+                no_crop=settings["no_crop"],
+                percent_retain=settings["percent_retain"],
+                margin_size=settings["margin_size"],
+                use_uniform=settings["use_uniform"],
+                use_same_size=settings["use_same_size"],
+                threshold=settings["threshold"],
             )
         except Exception as exc:
             error_text = str(exc)
             root.after(0, lambda error_text=error_text: on_export_failure(error_text))
             return
 
-        root.after(0, on_export_success)
+        root.after(0, lambda settings=settings: on_export_success(settings))
 
     def on_export_failure(error_text):
         exporting["active"] = False
@@ -556,10 +574,15 @@ def main():
             return
         if from_history:
             apply_history_item(get_selected_history_item())
+        try:
+            settings = collect_export_settings()
+        except Exception as exc:
+            on_export_failure(str(exc))
+            return
         exporting["active"] = True
         export_button.configure(state=tk.DISABLED)
         set_status("gui.file.status.exporting")
-        threading.Thread(target=run_export, daemon=True).start()
+        threading.Thread(target=run_export, args=(settings,), daemon=True).start()
 
     def update_texts():
         current = translator()

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -9,6 +9,7 @@ from tkinter import filedialog, messagebox, ttk
 from . import __version__
 from .cli import default_output_path
 from .core import detect_backends, export_selected_pages, parse_page_range
+from .i18n import DEFAULT_LANGUAGE, get_translator
 
 
 FILE_MODE_HISTORY_PATH = Path.home() / ".ppt2fig_file_history.json"
@@ -37,15 +38,15 @@ def _save_file_mode_history(items):
         pass
 
 
-def _history_label(item):
+def _history_label(item, translator):
     source = item.get("source", "")
-    name = Path(source).name if source else "未命名"
+    name = Path(source).name if source else translator("gui.file.history_untitled")
     pages = item.get("pages", "")
     backend = item.get("backend", "auto")
     updated_at = item.get("updated_at", "")
     short_time = updated_at[5:16].replace("T", " ") if len(updated_at) >= 16 else ""
     prefix = f"[{short_time}] " if short_time else ""
-    return f"{prefix}{name} | 页码 {pages} | {backend}"
+    return translator("gui.file.history_label", prefix=prefix, name=name, pages=pages, backend=backend)
 
 
 def _record_current_settings(
@@ -92,17 +93,16 @@ def _record_current_settings(
     return filtered[:MAX_HISTORY_ITEMS]
 
 
-def _make_output_path(source_text, pages_text):
+def _make_output_path(source_text, pages_text, *, lang=DEFAULT_LANGUAGE):
     source = Path(source_text).resolve()
-    pages = parse_page_range(pages_text)
+    pages = parse_page_range(pages_text, lang=lang)
     return str(default_output_path(source, pages))
 
 
 def main():
     root = tk.Tk()
-    root.title(f"PPT2Fig 文件模式 v{__version__}")
-    root.geometry("980x690")
-    root.minsize(920, 640)
+    root.geometry("1020x730")
+    root.minsize(960, 680)
 
     source_var = tk.StringVar()
     pages_var = tk.StringVar(value="1")
@@ -118,14 +118,26 @@ def main():
     use_same_size_var = tk.BooleanVar(value=True)
     threshold_var = tk.IntVar(value=191)
     auto_output_var = tk.BooleanVar(value=True)
-    status_var = tk.StringVar(value="选择文件后即可导出，常用配置会自动进入左侧历史记录。")
-    backend_status_var = tk.StringVar(value="未检测后端")
+    language_var = tk.StringVar(value=DEFAULT_LANGUAGE)
+    status_var = tk.StringVar()
+    backend_status_var = tk.StringVar()
+
     exporting = {"active": False}
     history_items = _load_file_mode_history()
+    selected_history_index = {"value": None}
+    status_state = {"key": "gui.file.status.ready", "kwargs": {}}
 
     style = ttk.Style()
     if "vista" in style.theme_names():
         style.theme_use("vista")
+
+    def translator():
+        return get_translator(language_var.get())
+
+    def set_status(key, **kwargs):
+        status_state["key"] = key
+        status_state["kwargs"] = kwargs
+        status_var.set(translator()(key, **kwargs))
 
     outer = ttk.Frame(root, padding=14)
     outer.pack(fill=tk.BOTH, expand=True)
@@ -134,13 +146,28 @@ def main():
     header.pack(fill=tk.X, pady=(0, 10))
     title_row = ttk.Frame(header)
     title_row.pack(fill=tk.X)
-    ttk.Label(title_row, text="PPT2Fig 文件模式", font=("Microsoft YaHei UI", 14, "bold")).pack(anchor="w", side=tk.LEFT)
-    ttk.Label(title_row, text=f"v{__version__}", foreground="#666666").pack(anchor="e", side=tk.RIGHT)
-    ttk.Label(
-        header,
-        text="面向重复导出场景：左侧保留最近任务，右侧编辑当前配置。",
-        foreground="#555555",
-    ).pack(anchor="w", pady=(2, 0))
+
+    title_label = ttk.Label(title_row, font=("Microsoft YaHei UI", 14, "bold"))
+    title_label.pack(anchor="w", side=tk.LEFT)
+
+    version_label = ttk.Label(title_row, text=f"v{__version__}", foreground="#666666")
+    version_label.pack(anchor="e", side=tk.RIGHT)
+
+    language_row = ttk.Frame(header)
+    language_row.pack(fill=tk.X, pady=(6, 0))
+    language_label = ttk.Label(language_row)
+    language_label.pack(side=tk.LEFT)
+    language_select = ttk.Combobox(
+        language_row,
+        textvariable=language_var,
+        values=("zh", "en"),
+        state="readonly",
+        width=6,
+    )
+    language_select.pack(side=tk.LEFT, padx=(8, 0))
+
+    subtitle_label = ttk.Label(header, foreground="#555555", wraplength=920, justify=tk.LEFT)
+    subtitle_label.pack(anchor="w", pady=(6, 0))
 
     body = ttk.PanedWindow(outer, orient=tk.HORIZONTAL)
     body.pack(fill=tk.BOTH, expand=True)
@@ -150,12 +177,10 @@ def main():
     form_panel = ttk.Frame(body)
     body.add(form_panel, weight=72)
 
-    ttk.Label(history_panel, text="最近任务", font=("Microsoft YaHei UI", 11, "bold")).pack(anchor="w")
-    ttk.Label(
-        history_panel,
-        text="双击可直接重导，单击后可载入到右侧编辑。",
-        foreground="#666666",
-    ).pack(anchor="w", pady=(2, 8))
+    history_title_label = ttk.Label(history_panel, font=("Microsoft YaHei UI", 11, "bold"))
+    history_title_label.pack(anchor="w")
+    history_subtitle_label = ttk.Label(history_panel, foreground="#666666", wraplength=250, justify=tk.LEFT)
+    history_subtitle_label.pack(anchor="w", pady=(2, 8))
 
     history_list = tk.Listbox(history_panel, activestyle="none", height=18)
     history_list.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
@@ -165,15 +190,168 @@ def main():
 
     history_actions = ttk.Frame(history_panel)
     history_actions.pack(fill=tk.X, pady=(8, 0))
+    load_button = ttk.Button(history_actions)
+    load_button.pack(side=tk.LEFT)
+    rerun_button = ttk.Button(history_actions)
+    rerun_button.pack(side=tk.LEFT, padx=6)
+    delete_button = ttk.Button(history_actions)
+    delete_button.pack(side=tk.LEFT)
 
-    selected_history_index = {"value": None}
+    current_label = ttk.Label(form_panel, font=("Microsoft YaHei UI", 11, "bold"))
+    current_label.pack(anchor="w")
 
-    def refresh_history_list(select_index=0):
+    quick_actions = ttk.Frame(form_panel)
+    quick_actions.pack(fill=tk.X, pady=(6, 10))
+    choose_file_button = ttk.Button(quick_actions)
+    choose_file_button.pack(side=tk.LEFT)
+    same_dir_button = ttk.Button(quick_actions)
+    same_dir_button.pack(side=tk.LEFT, padx=6)
+    refresh_backends_button = ttk.Button(quick_actions)
+    refresh_backends_button.pack(side=tk.LEFT, padx=6)
+    auto_output_check = ttk.Checkbutton(quick_actions, variable=auto_output_var)
+    auto_output_check.pack(side=tk.RIGHT)
+
+    basic_frame = ttk.LabelFrame(form_panel, padding=12)
+    basic_frame.pack(fill=tk.X)
+    basic_frame.columnconfigure(1, weight=1)
+
+    source_label = ttk.Label(basic_frame)
+    source_label.grid(row=0, column=0, sticky="w", pady=5)
+    ttk.Entry(basic_frame, textvariable=source_var).grid(row=0, column=1, sticky="ew", padx=8, pady=5)
+    source_browse_button = ttk.Button(basic_frame)
+    source_browse_button.grid(row=0, column=2, sticky="e", pady=5)
+
+    pages_label = ttk.Label(basic_frame)
+    pages_label.grid(row=1, column=0, sticky="w", pady=5)
+    pages_row = ttk.Frame(basic_frame)
+    pages_row.grid(row=1, column=1, sticky="ew", padx=8, pady=5)
+    pages_row.columnconfigure(0, weight=1)
+    ttk.Entry(pages_row, textvariable=pages_var).grid(row=0, column=0, sticky="ew")
+    pages_hint_label = ttk.Label(pages_row, foreground="#666666")
+    pages_hint_label.grid(row=0, column=1, sticky="w", padx=(8, 0))
+    first_page_button = ttk.Button(basic_frame, command=lambda: pages_var.set("1"))
+    first_page_button.grid(row=1, column=2, sticky="e", pady=5)
+
+    output_label = ttk.Label(basic_frame)
+    output_label.grid(row=2, column=0, sticky="w", pady=5)
+    ttk.Entry(basic_frame, textvariable=output_var).grid(row=2, column=1, sticky="ew", padx=8, pady=5)
+    output_browse_button = ttk.Button(basic_frame)
+    output_browse_button.grid(row=2, column=2, sticky="e", pady=5)
+
+    backend_frame = ttk.LabelFrame(form_panel, padding=12)
+    backend_frame.pack(fill=tk.X, pady=(10, 0))
+    backend_frame.columnconfigure(1, weight=1)
+
+    backend_label = ttk.Label(backend_frame)
+    backend_label.grid(row=0, column=0, sticky="w", pady=5)
+    backend_select = ttk.Combobox(
+        backend_frame,
+        textvariable=backend_var,
+        values=["auto", "libreoffice", "wps", "powerpoint"],
+        state="readonly",
+    )
+    backend_select.grid(row=0, column=1, sticky="ew", padx=8, pady=5)
+    backend_refresh_button = ttk.Button(backend_frame)
+    backend_refresh_button.grid(row=0, column=2, sticky="e", pady=5)
+
+    program_path_label = ttk.Label(backend_frame)
+    program_path_label.grid(row=1, column=0, sticky="w", pady=5)
+    ttk.Entry(backend_frame, textvariable=office_bin_var).grid(row=1, column=1, sticky="ew", padx=8, pady=5)
+    office_bin_browse_button = ttk.Button(backend_frame)
+    office_bin_browse_button.grid(row=1, column=2, sticky="e", pady=5)
+
+    detection_status_label = ttk.Label(backend_frame)
+    detection_status_label.grid(row=2, column=0, sticky="nw", pady=5)
+    ttk.Label(backend_frame, textvariable=backend_status_var, foreground="#555555", justify=tk.LEFT).grid(
+        row=2, column=1, columnspan=2, sticky="w", padx=8, pady=5
+    )
+
+    powerpoint_frame = ttk.LabelFrame(form_panel, padding=12)
+    powerpoint_frame.pack(fill=tk.X, pady=(10, 0))
+    export_intent_label = ttk.Label(powerpoint_frame)
+    export_intent_label.grid(row=0, column=0, sticky="w", pady=5)
+    powerpoint_intent_select = ttk.Combobox(
+        powerpoint_frame,
+        textvariable=powerpoint_intent_var,
+        values=["print", "screen"],
+        state="readonly",
+        width=14,
+    )
+    powerpoint_intent_select.grid(row=0, column=1, sticky="w", padx=8, pady=5)
+    bitmap_missing_fonts_check = ttk.Checkbutton(powerpoint_frame, variable=bitmap_missing_fonts_var)
+    bitmap_missing_fonts_check.grid(row=0, column=2, sticky="w", pady=5)
+
+    crop_frame = ttk.LabelFrame(form_panel, padding=12)
+    crop_frame.pack(fill=tk.X, pady=(10, 0))
+
+    preset_row = ttk.Frame(crop_frame)
+    preset_row.pack(fill=tk.X, pady=(0, 8))
+    no_crop_check = ttk.Checkbutton(preset_row, variable=no_crop_var)
+    no_crop_check.pack(side=tk.LEFT)
+    tight_crop_button = ttk.Button(
+        preset_row,
+        command=lambda: (percent_retain_var.set(0), margin_size_var.set(0)),
+    )
+    tight_crop_button.pack(side=tk.LEFT, padx=(12, 4))
+    small_margin_button = ttk.Button(
+        preset_row,
+        command=lambda: (percent_retain_var.set(0), margin_size_var.set(3)),
+    )
+    small_margin_button.pack(side=tk.LEFT, padx=4)
+    medium_margin_button = ttk.Button(
+        preset_row,
+        command=lambda: (percent_retain_var.set(0), margin_size_var.set(6)),
+    )
+    medium_margin_button.pack(side=tk.LEFT, padx=4)
+    keep_original_button = ttk.Button(
+        preset_row,
+        command=lambda: (percent_retain_var.set(10), margin_size_var.set(0)),
+    )
+    keep_original_button.pack(side=tk.LEFT, padx=4)
+
+    crop_grid = ttk.Frame(crop_frame)
+    crop_grid.pack(fill=tk.X)
+    crop_grid.columnconfigure(1, weight=1)
+    crop_grid.columnconfigure(3, weight=1)
+
+    percent_label = ttk.Label(crop_grid)
+    percent_label.grid(row=0, column=0, sticky="w", pady=4)
+    percent_spin = ttk.Spinbox(crop_grid, from_=0, to=100, increment=1, textvariable=percent_retain_var, width=10)
+    percent_spin.grid(row=0, column=1, sticky="w", padx=(8, 20), pady=4)
+
+    margin_label = ttk.Label(crop_grid)
+    margin_label.grid(row=0, column=2, sticky="w", pady=4)
+    margin_spin = ttk.Spinbox(crop_grid, from_=0, to=50, increment=0.5, textvariable=margin_size_var, width=10)
+    margin_spin.grid(row=0, column=3, sticky="w", padx=8, pady=4)
+
+    threshold_label = ttk.Label(crop_grid)
+    threshold_label.grid(row=1, column=0, sticky="w", pady=4)
+    threshold_spin = ttk.Spinbox(crop_grid, from_=0, to=255, increment=1, textvariable=threshold_var, width=10)
+    threshold_spin.grid(row=1, column=1, sticky="w", padx=(8, 20), pady=4)
+
+    uniform_check = ttk.Checkbutton(crop_grid, variable=use_uniform_var)
+    uniform_check.grid(row=1, column=2, sticky="w", pady=4)
+    same_size_check = ttk.Checkbutton(crop_grid, variable=use_same_size_var)
+    same_size_check.grid(row=1, column=3, sticky="w", padx=8, pady=4)
+
+    footer = ttk.Frame(form_panel)
+    footer.pack(fill=tk.X, pady=(12, 0))
+    ttk.Label(footer, textvariable=status_var, foreground="#444444", justify=tk.LEFT, wraplength=650).pack(
+        side=tk.LEFT, fill=tk.X, expand=True
+    )
+    export_button = ttk.Button(footer)
+    export_button.pack(side=tk.RIGHT)
+
+    def refresh_history_list(select_index=None):
         history_list.delete(0, tk.END)
+        current = translator()
         for item in history_items:
-            history_list.insert(tk.END, _history_label(item))
+            history_list.insert(tk.END, _history_label(item, current))
         if history_items:
-            idx = min(select_index, len(history_items) - 1)
+            idx = selected_history_index["value"] if select_index is None else select_index
+            if idx is None:
+                idx = 0
+            idx = min(max(idx, 0), len(history_items) - 1)
             history_list.selection_clear(0, tk.END)
             history_list.selection_set(idx)
             history_list.activate(idx)
@@ -190,6 +368,29 @@ def main():
         if 0 <= idx < len(history_items):
             return history_items[idx]
         return None
+
+    def update_dynamic_state(*_args):
+        crop_enabled = not no_crop_var.get()
+        state = tk.NORMAL if crop_enabled else tk.DISABLED
+        for widget in (percent_spin, margin_spin, threshold_spin):
+            widget.configure(state=state)
+        for widget in (uniform_check, same_size_check):
+            widget.configure(state=tk.NORMAL if crop_enabled else tk.DISABLED)
+
+        is_powerpoint = backend_var.get() == "powerpoint"
+        powerpoint_intent_select.configure(state="readonly" if is_powerpoint else tk.DISABLED)
+        bitmap_missing_fonts_check.configure(state=tk.NORMAL if is_powerpoint else tk.DISABLED)
+
+    def refresh_backends(verbose=False):
+        current = translator()
+        labels = []
+        for backend in detect_backends(explicit_path=office_bin_var.get() or None, lang=language_var.get()):
+            mark = current("cli.backend.supported") if backend.supported else current("cli.backend.detected")
+            detail = f" - {backend.detail}" if backend.detail else ""
+            labels.append(f"{backend.name} ({mark}){detail}")
+        backend_status_var.set("\n".join(labels) if labels else current("gui.file.backend_none_detected"))
+        if verbose:
+            set_status("gui.file.status.refreshed_backends")
 
     def apply_history_item(item):
         if not item:
@@ -209,7 +410,7 @@ def main():
         threshold_var.set(int(item.get("threshold", 191)))
         auto_output_var.set(False)
         update_dynamic_state()
-        status_var.set("已载入历史任务，可直接修改后重新导出。")
+        set_status("gui.file.status.loaded_history")
 
     def delete_history_item():
         item = get_selected_history_item()
@@ -219,50 +420,35 @@ def main():
         del history_items[idx]
         _save_file_mode_history(history_items)
         refresh_history_list(max(0, idx - 1))
-        status_var.set("已删除一条历史任务。")
-
-    ttk.Button(history_actions, text="载入", command=lambda: apply_history_item(get_selected_history_item())).pack(
-        side=tk.LEFT
-    )
-    ttk.Button(history_actions, text="重导", command=lambda: start_export(from_history=True)).pack(
-        side=tk.LEFT, padx=6
-    )
-    ttk.Button(history_actions, text="删除", command=delete_history_item).pack(side=tk.LEFT)
-
-    history_list.bind("<<ListboxSelect>>", lambda _event: get_selected_history_item())
-    history_list.bind(
-        "<Double-Button-1>",
-        lambda _event: (apply_history_item(get_selected_history_item()), start_export(from_history=True)),
-    )
-
-    current_label = ttk.Label(form_panel, text="当前配置", font=("Microsoft YaHei UI", 11, "bold"))
-    current_label.pack(anchor="w")
-
-    quick_actions = ttk.Frame(form_panel)
-    quick_actions.pack(fill=tk.X, pady=(6, 10))
+        set_status("gui.file.status.deleted_history")
 
     def choose_source():
+        current = translator()
         selected = filedialog.askopenfilename(
             parent=root,
-            title="选择输入文件",
-            filetypes=[("Presentation", "*.pptx *.ppt *.odp"), ("All files", "*.*")],
+            title=current("gui.file.dialog.select_input"),
+            filetypes=[
+                (current("common.filetype.presentation"), "*.pptx *.ppt *.odp"),
+                (current("common.filetype.all_files"), "*.*"),
+            ],
         )
         if not selected:
             return
         source_var.set(selected)
         if auto_output_var.get():
             try:
-                output_var.set(_make_output_path(selected, pages_var.get()))
+                output_var.set(_make_output_path(selected, pages_var.get(), lang=language_var.get()))
             except Exception:
                 pass
-        status_var.set("已选择输入文件。")
+        set_status("gui.file.status.selected_file")
 
     def choose_output():
+        current = translator()
         selected = filedialog.asksaveasfilename(
             parent=root,
-            title="选择输出 PDF",
+            title=current("gui.file.dialog.select_output"),
             defaultextension=".pdf",
-            filetypes=[("PDF file", "*.pdf")],
+            filetypes=[(current("common.filetype.pdf"), "*.pdf")],
             initialfile=os.path.basename(output_var.get()) if output_var.get() else "",
             initialdir=os.path.dirname(output_var.get()) if output_var.get() else "",
         )
@@ -271,7 +457,8 @@ def main():
             auto_output_var.set(False)
 
     def choose_office_bin():
-        selected = filedialog.askopenfilename(parent=root, title="选择后端可执行文件")
+        current = translator()
+        selected = filedialog.askopenfilename(parent=root, title=current("gui.file.dialog.select_backend_bin"))
         if selected:
             office_bin_var.set(selected)
             refresh_backends()
@@ -279,223 +466,29 @@ def main():
     def set_output_from_input():
         if not source_var.get():
             return
-        output_var.set(_make_output_path(source_var.get(), pages_var.get()))
-
-    ttk.Button(quick_actions, text="选择文件", command=choose_source).pack(side=tk.LEFT)
-    ttk.Button(quick_actions, text="输出同目录", command=set_output_from_input).pack(side=tk.LEFT, padx=6)
-    ttk.Button(quick_actions, text="刷新后端", command=lambda: refresh_backends(verbose=True)).pack(
-        side=tk.LEFT, padx=6
-    )
-    ttk.Checkbutton(
-        quick_actions,
-        text="自动生成输出文件名",
-        variable=auto_output_var,
-        command=lambda: set_output_from_input() if auto_output_var.get() and source_var.get() else None,
-    ).pack(side=tk.RIGHT)
-
-    basic_frame = ttk.LabelFrame(form_panel, text="基础信息", padding=12)
-    basic_frame.pack(fill=tk.X)
-    basic_frame.columnconfigure(1, weight=1)
-
-    ttk.Label(basic_frame, text="输入文件").grid(row=0, column=0, sticky="w", pady=5)
-    ttk.Entry(basic_frame, textvariable=source_var).grid(row=0, column=1, sticky="ew", padx=8, pady=5)
-    ttk.Button(basic_frame, text="浏览", command=choose_source).grid(row=0, column=2, sticky="e", pady=5)
-
-    ttk.Label(basic_frame, text="页码").grid(row=1, column=0, sticky="w", pady=5)
-    pages_row = ttk.Frame(basic_frame)
-    pages_row.grid(row=1, column=1, sticky="ew", padx=8, pady=5)
-    pages_row.columnconfigure(0, weight=1)
-    ttk.Entry(pages_row, textvariable=pages_var).grid(row=0, column=0, sticky="ew")
-    ttk.Label(pages_row, text="支持 1,3,5-7", foreground="#666666").grid(row=0, column=1, sticky="w", padx=(8, 0))
-    ttk.Button(basic_frame, text="第一页", command=lambda: pages_var.set("1")).grid(row=1, column=2, sticky="e", pady=5)
-
-    ttk.Label(basic_frame, text="输出 PDF").grid(row=2, column=0, sticky="w", pady=5)
-    ttk.Entry(basic_frame, textvariable=output_var).grid(row=2, column=1, sticky="ew", padx=8, pady=5)
-    ttk.Button(basic_frame, text="浏览", command=choose_output).grid(row=2, column=2, sticky="e", pady=5)
-
-    backend_frame = ttk.LabelFrame(form_panel, text="导出后端", padding=12)
-    backend_frame.pack(fill=tk.X, pady=(10, 0))
-    backend_frame.columnconfigure(1, weight=1)
-
-    ttk.Label(backend_frame, text="后端").grid(row=0, column=0, sticky="w", pady=5)
-    backend_select = ttk.Combobox(
-        backend_frame,
-        textvariable=backend_var,
-        values=["auto", "libreoffice", "wps", "powerpoint"],
-        state="readonly",
-    )
-    backend_select.grid(row=0, column=1, sticky="ew", padx=8, pady=5)
-    ttk.Button(backend_frame, text="刷新", command=lambda: refresh_backends(verbose=True)).grid(
-        row=0, column=2, sticky="e", pady=5
-    )
-
-    ttk.Label(backend_frame, text="程序路径").grid(row=1, column=0, sticky="w", pady=5)
-    ttk.Entry(backend_frame, textvariable=office_bin_var).grid(row=1, column=1, sticky="ew", padx=8, pady=5)
-    ttk.Button(backend_frame, text="浏览", command=choose_office_bin).grid(row=1, column=2, sticky="e", pady=5)
-
-    ttk.Label(backend_frame, text="检测状态").grid(row=2, column=0, sticky="nw", pady=5)
-    ttk.Label(backend_frame, textvariable=backend_status_var, foreground="#555555", justify=tk.LEFT).grid(
-        row=2, column=1, columnspan=2, sticky="w", padx=8, pady=5
-    )
-
-    powerpoint_frame = ttk.LabelFrame(form_panel, text="PowerPoint 特定选项", padding=12)
-    powerpoint_frame.pack(fill=tk.X, pady=(10, 0))
-
-    ttk.Label(powerpoint_frame, text="导出意图").grid(row=0, column=0, sticky="w", pady=5)
-    powerpoint_intent_select = ttk.Combobox(
-        powerpoint_frame,
-        textvariable=powerpoint_intent_var,
-        values=["print", "screen"],
-        state="readonly",
-        width=14,
-    )
-    powerpoint_intent_select.grid(row=0, column=1, sticky="w", padx=8, pady=5)
-
-    bitmap_missing_fonts_check = ttk.Checkbutton(
-        powerpoint_frame,
-        text="缺字库时将文字位图化",
-        variable=bitmap_missing_fonts_var,
-    )
-    bitmap_missing_fonts_check.grid(row=0, column=2, sticky="w", pady=5)
-
-    crop_frame = ttk.LabelFrame(form_panel, text="裁剪与页面设置", padding=12)
-    crop_frame.pack(fill=tk.X, pady=(10, 0))
-
-    preset_row = ttk.Frame(crop_frame)
-    preset_row.pack(fill=tk.X, pady=(0, 8))
-    ttk.Checkbutton(preset_row, text="不裁剪", variable=no_crop_var).pack(side=tk.LEFT)
-    ttk.Button(
-        preset_row,
-        text="紧密裁剪",
-        command=lambda: (percent_retain_var.set(0), margin_size_var.set(0)),
-    ).pack(side=tk.LEFT, padx=(12, 4))
-    ttk.Button(
-        preset_row,
-        text="小白边",
-        command=lambda: (percent_retain_var.set(0), margin_size_var.set(3)),
-    ).pack(side=tk.LEFT, padx=4)
-    ttk.Button(
-        preset_row,
-        text="中白边",
-        command=lambda: (percent_retain_var.set(0), margin_size_var.set(6)),
-    ).pack(side=tk.LEFT, padx=4)
-    ttk.Button(
-        preset_row,
-        text="保留原边距",
-        command=lambda: (percent_retain_var.set(10), margin_size_var.set(0)),
-    ).pack(side=tk.LEFT, padx=4)
-
-    crop_grid = ttk.Frame(crop_frame)
-    crop_grid.pack(fill=tk.X)
-    crop_grid.columnconfigure(1, weight=1)
-    crop_grid.columnconfigure(3, weight=1)
-
-    ttk.Label(crop_grid, text="保留原边距(%)").grid(row=0, column=0, sticky="w", pady=4)
-    percent_spin = ttk.Spinbox(crop_grid, from_=0, to=100, increment=1, textvariable=percent_retain_var, width=10)
-    percent_spin.grid(row=0, column=1, sticky="w", padx=(8, 20), pady=4)
-
-    ttk.Label(crop_grid, text="额外白边(bp)").grid(row=0, column=2, sticky="w", pady=4)
-    margin_spin = ttk.Spinbox(crop_grid, from_=0, to=50, increment=0.5, textvariable=margin_size_var, width=10)
-    margin_spin.grid(row=0, column=3, sticky="w", padx=8, pady=4)
-
-    ttk.Label(crop_grid, text="检测阈值").grid(row=1, column=0, sticky="w", pady=4)
-    threshold_spin = ttk.Spinbox(crop_grid, from_=0, to=255, increment=1, textvariable=threshold_var, width=10)
-    threshold_spin.grid(row=1, column=1, sticky="w", padx=(8, 20), pady=4)
-
-    uniform_check = ttk.Checkbutton(crop_grid, text="统一裁剪", variable=use_uniform_var)
-    uniform_check.grid(row=1, column=2, sticky="w", pady=4)
-    same_size_check = ttk.Checkbutton(crop_grid, text="统一页面大小", variable=use_same_size_var)
-    same_size_check.grid(row=1, column=3, sticky="w", padx=8, pady=4)
-
-    footer = ttk.Frame(form_panel)
-    footer.pack(fill=tk.X, pady=(12, 0))
-
-    ttk.Label(footer, textvariable=status_var, foreground="#444444", justify=tk.LEFT).pack(
-        side=tk.LEFT, fill=tk.X, expand=True
-    )
-
-    export_button = ttk.Button(footer, text="导出当前配置")
-    export_button.pack(side=tk.RIGHT)
-
-    def update_dynamic_state(*_args):
-        crop_enabled = not no_crop_var.get()
-        state = tk.NORMAL if crop_enabled else tk.DISABLED
-        for widget in (percent_spin, margin_spin, threshold_spin):
-            widget.configure(state=state)
-        for widget in (uniform_check, same_size_check):
-            widget.configure(state=tk.NORMAL if crop_enabled else tk.DISABLED)
-
-        backend = backend_var.get()
-        is_powerpoint = backend == "powerpoint"
-        ppt_state = "readonly" if is_powerpoint else tk.DISABLED
-        powerpoint_intent_select.configure(state=ppt_state)
-        bitmap_missing_fonts_check.configure(state=tk.NORMAL if is_powerpoint else tk.DISABLED)
-
-    def refresh_backends(verbose=False):
-        labels = []
-        for backend in detect_backends(explicit_path=office_bin_var.get() or None):
-            mark = "supported" if backend.supported else "detected"
-            detail = f" - {backend.detail}" if backend.detail else ""
-            labels.append(f"{backend.name} ({mark}){detail}")
-        backend_status_var.set("\n".join(labels) if labels else "未检测到可用后端")
-        if verbose:
-            status_var.set("已刷新后端检测结果。")
+        output_var.set(_make_output_path(source_var.get(), pages_var.get(), lang=language_var.get()))
 
     def on_source_or_pages_changed(*_args):
         if auto_output_var.get() and source_var.get():
             try:
-                output_var.set(_make_output_path(source_var.get(), pages_var.get()))
+                output_var.set(_make_output_path(source_var.get(), pages_var.get(), lang=language_var.get()))
             except Exception:
                 pass
 
     def validate_form():
+        current = translator()
         source = source_var.get().strip()
         if not source:
-            raise ValueError("请选择输入文件")
+            raise ValueError(current("gui.file.error.select_input"))
         path = Path(source).resolve()
         if not path.exists():
-            raise ValueError("输入文件不存在")
-        pages = parse_page_range(pages_var.get().strip())
+            raise ValueError(current("gui.file.error.input_not_found"))
+        pages = parse_page_range(pages_var.get().strip(), lang=language_var.get())
         output = output_var.get().strip()
         if not output:
-            output = _make_output_path(source, pages_var.get().strip())
+            output = _make_output_path(source, pages_var.get().strip(), lang=language_var.get())
             output_var.set(output)
         return path, pages, output
-
-    def run_export():
-        try:
-            source, pages, output = validate_form()
-            export_selected_pages(
-                source,
-                output,
-                pages,
-                backend=backend_var.get(),
-                office_bin=office_bin_var.get().strip() or None,
-                powerpoint_intent=powerpoint_intent_var.get(),
-                bitmap_missing_fonts=bitmap_missing_fonts_var.get(),
-                no_crop=no_crop_var.get(),
-                percent_retain=percent_retain_var.get(),
-                margin_size=margin_size_var.get(),
-                use_uniform=use_uniform_var.get(),
-                use_same_size=use_same_size_var.get(),
-                threshold=threshold_var.get(),
-            )
-        except Exception as exc:
-            root.after(
-                0,
-                lambda: (
-                    status_var.set(f"导出失败: {exc}"),
-                    messagebox.showerror("错误", str(exc), parent=root),
-                    exporting.__setitem__("active", False),
-                    export_button.configure(state=tk.NORMAL),
-                ),
-            )
-            return
-
-        root.after(
-            0,
-            lambda: on_export_success(),
-        )
 
     def on_export_success():
         history_items[:] = _record_current_settings(
@@ -516,10 +509,46 @@ def main():
         )
         _save_file_mode_history(history_items)
         refresh_history_list(0)
-        status_var.set(f"导出完成: {output_var.get()}")
+        set_status("gui.file.status.export_done", path=output_var.get())
         exporting["active"] = False
         export_button.configure(state=tk.NORMAL)
-        messagebox.showinfo("成功", f"PDF已导出至：\n{output_var.get()}", parent=root)
+        current = translator()
+        messagebox.showinfo(
+            current("common.success"),
+            current("gui.quick.success_message", path=output_var.get()),
+            parent=root,
+        )
+
+    def run_export():
+        try:
+            source, pages, output = validate_form()
+            export_selected_pages(
+                source,
+                output,
+                pages,
+                lang=language_var.get(),
+                backend=backend_var.get(),
+                office_bin=office_bin_var.get().strip() or None,
+                powerpoint_intent=powerpoint_intent_var.get(),
+                bitmap_missing_fonts=bitmap_missing_fonts_var.get(),
+                no_crop=no_crop_var.get(),
+                percent_retain=percent_retain_var.get(),
+                margin_size=margin_size_var.get(),
+                use_uniform=use_uniform_var.get(),
+                use_same_size=use_same_size_var.get(),
+                threshold=threshold_var.get(),
+            )
+        except Exception as exc:
+            root.after(0, lambda: on_export_failure(str(exc)))
+            return
+
+        root.after(0, on_export_success)
+
+    def on_export_failure(error_text):
+        exporting["active"] = False
+        export_button.configure(state=tk.NORMAL)
+        set_status("gui.file.status.export_failed", error=error_text)
+        messagebox.showerror(translator()("common.error"), error_text, parent=root)
 
     def start_export(from_history=False):
         if exporting["active"]:
@@ -528,17 +557,89 @@ def main():
             apply_history_item(get_selected_history_item())
         exporting["active"] = True
         export_button.configure(state=tk.DISABLED)
-        status_var.set("正在导出，请稍候...")
+        set_status("gui.file.status.exporting")
         threading.Thread(target=run_export, daemon=True).start()
 
-    export_button.configure(command=start_export)
+    def update_texts():
+        current = translator()
+        root.title(current("gui.file.title", version=__version__))
+        language_label.config(text=current("lang.label"))
+        title_label.config(text=current("gui.file.header_title"))
+        subtitle_label.config(text=current("gui.file.header_subtitle"))
+        history_title_label.config(text=current("gui.file.history_title"))
+        history_subtitle_label.config(text=current("gui.file.history_subtitle"))
+        load_button.config(text=current("common.load"))
+        rerun_button.config(text=current("gui.file.history_rerun"))
+        delete_button.config(text=current("common.delete"))
+        current_label.config(text=current("gui.file.current_title"))
+        choose_file_button.config(text=current("gui.file.choose_file"))
+        same_dir_button.config(text=current("gui.file.output_same_dir"))
+        refresh_backends_button.config(text=current("gui.file.refresh_backends"))
+        auto_output_check.config(text=current("gui.file.auto_output_name"))
+        basic_frame.config(text=current("gui.file.section_basic"))
+        source_label.config(text=current("gui.file.field_source"))
+        source_browse_button.config(text=current("common.browse"))
+        pages_label.config(text=current("gui.file.field_pages"))
+        pages_hint_label.config(text=current("gui.file.pages_hint"))
+        first_page_button.config(text=current("gui.file.first_page"))
+        output_label.config(text=current("gui.file.field_output"))
+        output_browse_button.config(text=current("common.browse"))
+        backend_frame.config(text=current("gui.file.section_backend"))
+        backend_label.config(text=current("gui.file.field_backend"))
+        backend_refresh_button.config(text=current("common.refresh"))
+        program_path_label.config(text=current("gui.file.field_program_path"))
+        office_bin_browse_button.config(text=current("common.browse"))
+        detection_status_label.config(text=current("gui.file.field_detection_status"))
+        powerpoint_frame.config(text=current("gui.file.section_powerpoint"))
+        export_intent_label.config(text=current("gui.file.field_export_intent"))
+        bitmap_missing_fonts_check.config(text=current("gui.file.bitmap_missing_fonts"))
+        crop_frame.config(text=current("gui.file.section_crop"))
+        no_crop_check.config(text=current("gui.crop.no_crop"))
+        tight_crop_button.config(text=current("gui.crop.preset.tight"))
+        small_margin_button.config(text=current("gui.crop.preset.small_margin"))
+        medium_margin_button.config(text=current("gui.crop.preset.medium_margin"))
+        keep_original_button.config(text=current("gui.crop.preset.keep_original"))
+        percent_label.config(text=current("gui.crop.percent").rstrip(":"))
+        margin_label.config(text=current("gui.crop.margin").rstrip(":"))
+        threshold_label.config(text=current("gui.crop.threshold").rstrip(":"))
+        uniform_check.config(text=current("gui.crop.uniform"))
+        same_size_check.config(text=current("gui.crop.same_size"))
+        export_button.config(text=current("gui.file.export_button"))
+        refresh_history_list(selected_history_index["value"])
+        refresh_backends(verbose=False)
+        status_var.set(current(status_state["key"], **status_state["kwargs"]))
 
+    load_button.config(command=lambda: apply_history_item(get_selected_history_item()))
+    rerun_button.config(command=lambda: start_export(from_history=True))
+    delete_button.config(command=delete_history_item)
+    choose_file_button.config(command=choose_source)
+    same_dir_button.config(command=set_output_from_input)
+    refresh_backends_button.config(command=lambda: refresh_backends(verbose=True))
+    source_browse_button.config(command=choose_source)
+    output_browse_button.config(command=choose_output)
+    backend_refresh_button.config(command=lambda: refresh_backends(verbose=True))
+    office_bin_browse_button.config(command=choose_office_bin)
+    export_button.config(command=start_export)
+    auto_output_check.config(
+        command=lambda: set_output_from_input() if auto_output_var.get() and source_var.get() else None
+    )
+
+    history_list.bind("<<ListboxSelect>>", lambda _event: get_selected_history_item())
+    history_list.bind(
+        "<Double-Button-1>",
+        lambda _event: (apply_history_item(get_selected_history_item()), start_export(from_history=True)),
+    )
     source_var.trace_add("write", on_source_or_pages_changed)
     pages_var.trace_add("write", on_source_or_pages_changed)
     backend_var.trace_add("write", update_dynamic_state)
     no_crop_var.trace_add("write", update_dynamic_state)
+    language_select.bind("<<ComboboxSelected>>", lambda _event: update_texts())
 
-    refresh_backends()
-    refresh_history_list()
+    set_status("gui.file.status.ready")
     update_dynamic_state()
+    update_texts()
     root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -2,6 +2,7 @@ import json
 import os
 import threading
 import tkinter as tk
+import ctypes
 from datetime import datetime
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
@@ -14,6 +15,27 @@ from .i18n import DEFAULT_LANGUAGE, get_translator
 
 FILE_MODE_HISTORY_PATH = Path.home() / ".ppt2fig_file_history.json"
 MAX_HISTORY_ITEMS = 16
+
+
+def _enable_high_dpi_support():
+    if os.name != "nt":
+        return
+
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except Exception:
+        try:
+            ctypes.windll.user32.SetProcessDPIAware()
+        except Exception:
+            pass
+
+
+def _fit_window(root, *, min_width, min_height, width_padding=48, height_padding=56):
+    root.update_idletasks()
+    width = max(min_width, root.winfo_reqwidth() + width_padding)
+    height = max(min_height, root.winfo_reqheight() + height_padding)
+    root.geometry(f"{width}x{height}")
+    root.minsize(width, height)
 
 
 def _load_file_mode_history():
@@ -100,9 +122,10 @@ def _make_output_path(source_text, pages_text, *, lang=DEFAULT_LANGUAGE):
 
 
 def main():
+    _enable_high_dpi_support()
     root = tk.Tk()
-    root.geometry("1020x730")
-    root.minsize(960, 680)
+    root.geometry("1120x820")
+    root.minsize(1120, 820)
 
     source_var = tk.StringVar()
     pages_var = tk.StringVar(value="1")
@@ -662,6 +685,7 @@ def main():
     set_status("gui.file.status.ready")
     update_dynamic_state()
     update_texts()
+    _fit_window(root, min_width=1120, min_height=820)
     root.mainloop()
 
 

--- a/ppt2fig/file_gui.py
+++ b/ppt2fig/file_gui.py
@@ -539,7 +539,8 @@ def main():
                 threshold=threshold_var.get(),
             )
         except Exception as exc:
-            root.after(0, lambda: on_export_failure(str(exc)))
+            error_text = str(exc)
+            root.after(0, lambda error_text=error_text: on_export_failure(error_text))
             return
 
         root.after(0, on_export_success)

--- a/ppt2fig/gui.py
+++ b/ppt2fig/gui.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, ttk
 
 from . import __version__
 from .core import (
@@ -10,6 +10,7 @@ from .core import (
     current_slide_2_pdf_windows,
     get_active_presentation_info,
 )
+from .i18n import DEFAULT_LANGUAGE, get_translator
 
 
 def _apply_crop_preset(percent_var, margin_var, preset_type):
@@ -30,46 +31,50 @@ def _apply_crop_preset(percent_var, margin_var, preset_type):
 def _build_crop_settings(parent, *, no_crop, margin_size, percent_retain, use_uniform, use_same_size, threshold):
     advanced_frame = tk.Frame(parent)
 
-    title_label = tk.Label(advanced_frame, text="PDF裁剪参数设置", font=("Arial", 10, "bold"))
+    title_label = tk.Label(advanced_frame, font=("Arial", 10, "bold"))
     title_label.pack(pady=(10, 5))
 
-    preset_frame = tk.LabelFrame(advanced_frame, text="快速设置", font=("Arial", 9))
+    preset_frame = tk.LabelFrame(advanced_frame, font=("Arial", 9))
     preset_frame.pack(fill=tk.X, pady=(0, 5))
 
     preset_buttons_frame = tk.Frame(preset_frame)
     preset_buttons_frame.pack(pady=5)
 
-    tk.Button(
+    tight_button = tk.Button(
         preset_buttons_frame,
-        text="紧密裁剪",
         font=("Arial", 8),
         command=lambda: _apply_crop_preset(percent_retain, margin_size, "tight"),
-    ).pack(side=tk.LEFT, padx=2)
-    tk.Button(
+    )
+    tight_button.pack(side=tk.LEFT, padx=2)
+
+    small_margin_button = tk.Button(
         preset_buttons_frame,
-        text="小白边",
         font=("Arial", 8),
         command=lambda: _apply_crop_preset(percent_retain, margin_size, "small_margin"),
-    ).pack(side=tk.LEFT, padx=2)
-    tk.Button(
+    )
+    small_margin_button.pack(side=tk.LEFT, padx=2)
+
+    medium_margin_button = tk.Button(
         preset_buttons_frame,
-        text="中白边",
         font=("Arial", 8),
         command=lambda: _apply_crop_preset(percent_retain, margin_size, "medium_margin"),
-    ).pack(side=tk.LEFT, padx=2)
-    tk.Button(
+    )
+    medium_margin_button.pack(side=tk.LEFT, padx=2)
+
+    keep_original_button = tk.Button(
         preset_buttons_frame,
-        text="保留原边距",
         font=("Arial", 8),
         command=lambda: _apply_crop_preset(percent_retain, margin_size, "keep_original"),
-    ).pack(side=tk.LEFT, padx=2)
+    )
+    keep_original_button.pack(side=tk.LEFT, padx=2)
 
-    params_frame = tk.LabelFrame(advanced_frame, text="详细参数", font=("Arial", 9))
+    params_frame = tk.LabelFrame(advanced_frame, font=("Arial", 9))
     params_frame.pack(fill=tk.X, pady=5)
 
     percent_frame = tk.Frame(params_frame)
     percent_frame.pack(fill=tk.X, pady=2)
-    tk.Label(percent_frame, text="保留原始边距(%):", width=15, anchor="w").pack(side=tk.LEFT)
+    percent_label = tk.Label(percent_frame, width=18, anchor="w")
+    percent_label.pack(side=tk.LEFT)
     tk.Spinbox(
         percent_frame,
         from_=0,
@@ -82,7 +87,8 @@ def _build_crop_settings(parent, *, no_crop, margin_size, percent_retain, use_un
 
     margin_frame = tk.Frame(params_frame)
     margin_frame.pack(fill=tk.X, pady=2)
-    tk.Label(margin_frame, text="额外白边(bp):", width=15, anchor="w").pack(side=tk.LEFT)
+    margin_label = tk.Label(margin_frame, width=18, anchor="w")
+    margin_label.pack(side=tk.LEFT)
     tk.Spinbox(
         margin_frame,
         from_=0,
@@ -95,7 +101,8 @@ def _build_crop_settings(parent, *, no_crop, margin_size, percent_retain, use_un
 
     threshold_frame = tk.Frame(params_frame)
     threshold_frame.pack(fill=tk.X, pady=2)
-    tk.Label(threshold_frame, text="检测阈值:", width=15, anchor="w").pack(side=tk.LEFT)
+    threshold_label = tk.Label(threshold_frame, width=18, anchor="w")
+    threshold_label.pack(side=tk.LEFT)
     tk.Spinbox(
         threshold_frame,
         from_=0,
@@ -108,23 +115,36 @@ def _build_crop_settings(parent, *, no_crop, margin_size, percent_retain, use_un
     options_frame = tk.Frame(params_frame)
     options_frame.pack(fill=tk.X, pady=2)
 
-    tk.Checkbutton(options_frame, text="不裁剪", variable=no_crop, font=("Arial", 8)).pack(
-        side=tk.LEFT, padx=5
-    )
-    tk.Checkbutton(options_frame, text="统一裁剪", variable=use_uniform, font=("Arial", 8)).pack(
-        side=tk.LEFT, padx=5
-    )
-    tk.Checkbutton(
-        options_frame, text="统一页面大小", variable=use_same_size, font=("Arial", 8)
-    ).pack(side=tk.LEFT, padx=5)
+    no_crop_check = tk.Checkbutton(options_frame, variable=no_crop, font=("Arial", 8))
+    no_crop_check.pack(side=tk.LEFT, padx=5)
+    uniform_check = tk.Checkbutton(options_frame, variable=use_uniform, font=("Arial", 8))
+    uniform_check.pack(side=tk.LEFT, padx=5)
+    same_size_check = tk.Checkbutton(options_frame, variable=use_same_size, font=("Arial", 8))
+    same_size_check.pack(side=tk.LEFT, padx=5)
 
-    return advanced_frame
+    text_widgets = {
+        "title": (title_label, "gui.crop.title"),
+        "preset_frame": (preset_frame, "gui.crop.quick"),
+        "tight": (tight_button, "gui.crop.preset.tight"),
+        "small_margin": (small_margin_button, "gui.crop.preset.small_margin"),
+        "medium_margin": (medium_margin_button, "gui.crop.preset.medium_margin"),
+        "keep_original": (keep_original_button, "gui.crop.preset.keep_original"),
+        "params_frame": (params_frame, "gui.crop.detail"),
+        "percent": (percent_label, "gui.crop.percent"),
+        "margin": (margin_label, "gui.crop.margin"),
+        "threshold": (threshold_label, "gui.crop.threshold"),
+        "no_crop": (no_crop_check, "gui.crop.no_crop"),
+        "uniform": (uniform_check, "gui.crop.uniform"),
+        "same_size": (same_size_check, "gui.crop.same_size"),
+    }
+    return advanced_frame, text_widgets
 
 
 def main():
     root = tk.Tk()
     default_path_map = {}
 
+    language_var = tk.StringVar(value=DEFAULT_LANGUAGE)
     no_crop = tk.BooleanVar(value=False)
     margin_size = tk.DoubleVar(value=0.0)
     percent_retain = tk.DoubleVar(value=0.0)
@@ -133,9 +153,98 @@ def main():
     threshold = tk.IntVar(value=191)
     show_advanced = tk.BooleanVar(value=False)
 
+    root.attributes("-topmost", True)
+    root.geometry("360x130")
+    root.resizable(False, False)
+
+    main_frame = tk.Frame(root)
+    main_frame.pack(padx=15, pady=10, fill=tk.BOTH, expand=True)
+
+    header_row = tk.Frame(main_frame)
+    header_row.pack(fill=tk.X)
+
+    version_label = tk.Label(
+        header_row,
+        text=f"ppt2fig v{__version__}",
+        font=("Arial", 8),
+        fg="#666666",
+    )
+    version_label.pack(side=tk.RIGHT)
+
+    language_label = tk.Label(header_row, font=("Arial", 9))
+    language_label.pack(side=tk.LEFT)
+
+    language_select = ttk.Combobox(
+        header_row,
+        textvariable=language_var,
+        values=("zh", "en"),
+        state="readonly",
+        width=6,
+    )
+    language_select.pack(side=tk.LEFT, padx=(6, 0))
+
+    convert_frame = tk.Frame(main_frame)
+    convert_frame.pack(fill=tk.X, pady=(10, 10))
+
+    convert_button = tk.Button(
+        convert_frame,
+        command=lambda: hello_callback(),
+        font=("Arial", 10, "bold"),
+        bg="#4CAF50",
+        fg="white",
+        width=14,
+        height=1,
+    )
+    convert_button.pack()
+
+    toggle_button = tk.Button(
+        main_frame,
+        command=lambda: [show_advanced.set(not show_advanced.get()), toggle_advanced()],
+        font=("Arial", 9),
+        relief=tk.FLAT,
+        fg="#666666",
+    )
+    toggle_button.pack()
+
+    advanced_frame, advanced_text_widgets = _build_crop_settings(
+        main_frame,
+        no_crop=no_crop,
+        margin_size=margin_size,
+        percent_retain=percent_retain,
+        use_uniform=use_uniform,
+        use_same_size=use_same_size,
+        threshold=threshold,
+    )
+
+    def translator():
+        return get_translator(language_var.get())
+
+    def update_texts():
+        current = translator()
+        root.title(current("gui.quick.title", version=__version__))
+        language_label.config(text=current("lang.label"))
+        convert_button.config(text=current("gui.quick.export_button"))
+        toggle_button.config(
+            text=current("gui.quick.hide_advanced")
+            if show_advanced.get()
+            else current("gui.quick.show_advanced")
+        )
+        for widget, key in advanced_text_widgets.values():
+            widget.config(text=current(key))
+
+    def toggle_advanced():
+        if show_advanced.get():
+            advanced_frame.pack(fill=tk.BOTH, expand=True, pady=(5, 0))
+            root.geometry("390x410")
+        else:
+            advanced_frame.pack_forget()
+            root.geometry("360x130")
+        update_texts()
+
     def hello_callback():
+        current = translator()
         try:
-            full_name, name = get_active_presentation_info()
+            full_name, name = get_active_presentation_info(lang=language_var.get())
             ppt_path = os.path.dirname(full_name)
             ppt_name = os.path.splitext(name)[0]
 
@@ -147,9 +256,10 @@ def main():
 
             pdf_file_name = filedialog.asksaveasfilename(
                 parent=root,
+                title=current("gui.quick.save_title"),
                 initialfile=os.path.basename(initial_file),
                 initialdir=os.path.dirname(initial_file),
-                filetypes=[("PDF file", "*.pdf")],
+                filetypes=[(current("common.filetype.pdf"), "*.pdf")],
             )
 
             if not pdf_file_name:
@@ -159,13 +269,14 @@ def main():
                 pdf_file_name = pdf_file_name + ".pdf"
 
             if platform.system() == "Windows":
-                success = current_slide_2_pdf_windows(pdf_file_name)
+                success = current_slide_2_pdf_windows(pdf_file_name, lang=language_var.get())
             else:
-                success = current_slide_2_pdf_mac(pdf_file_name)
+                success = current_slide_2_pdf_mac(pdf_file_name, lang=language_var.get())
 
             if success:
                 crop_pdf_file(
                     pdf_file_name,
+                    lang=language_var.get(),
                     no_crop=no_crop.get(),
                     percent_retain=percent_retain.get(),
                     margin_size=margin_size.get(),
@@ -173,69 +284,20 @@ def main():
                     use_same_size=use_same_size.get(),
                     threshold=threshold.get(),
                 )
-                messagebox.showinfo("成功", f"PDF已导出至：\n{pdf_file_name}")
+                messagebox.showinfo(
+                    current("common.success"),
+                    current("gui.quick.success_message", path=pdf_file_name),
+                    parent=root,
+                )
             else:
-                messagebox.showerror("错误", "转换失败")
+                messagebox.showerror(current("common.error"), current("gui.quick.convert_failed"), parent=root)
         except Exception as exc:
-            messagebox.showerror("错误", str(exc))
+            messagebox.showerror(current("common.error"), str(exc), parent=root)
 
-    root.attributes("-topmost", True)
-    root.title(f"PPT转PDF工具 v{__version__}")
-    root.geometry("300x100")
-    root.resizable(False, False)
-
-    main_frame = tk.Frame(root)
-    main_frame.pack(padx=15, pady=10, fill=tk.BOTH, expand=True)
-
-    tk.Label(
-        main_frame,
-        text=f"ppt2fig v{__version__}",
-        font=("Arial", 8),
-        fg="#666666",
-    ).pack(anchor="ne")
-
-    convert_frame = tk.Frame(main_frame)
-    convert_frame.pack(fill=tk.X, pady=(0, 10))
-
-    tk.Button(
-        convert_frame,
-        text="转PDF",
-        command=hello_callback,
-        font=("Arial", 10, "bold"),
-        bg="#4CAF50",
-        fg="white",
-        width=10,
-        height=1,
-    ).pack()
-
-    def toggle_advanced():
-        if show_advanced.get():
-            advanced_frame.pack(fill=tk.BOTH, expand=True, pady=(5, 0))
-            toggle_button.config(text="▲ 隐藏高级设置")
-            root.geometry("320x380")
-        else:
-            advanced_frame.pack_forget()
-            toggle_button.config(text="▼ 显示高级设置")
-            root.geometry("300x100")
-
-    toggle_button = tk.Button(
-        main_frame,
-        text="▼ 显示高级设置",
-        command=lambda: [show_advanced.set(not show_advanced.get()), toggle_advanced()],
-        font=("Arial", 9),
-        relief=tk.FLAT,
-        fg="#666",
-    )
-    toggle_button.pack()
-
-    advanced_frame = _build_crop_settings(
-        main_frame,
-        no_crop=no_crop,
-        margin_size=margin_size,
-        percent_retain=percent_retain,
-        use_uniform=use_uniform,
-        use_same_size=use_same_size,
-        threshold=threshold,
-    )
-
+    language_select.bind("<<ComboboxSelected>>", lambda _event: update_texts())
+    update_texts()
     root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/ppt2fig/gui.py
+++ b/ppt2fig/gui.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import tkinter as tk
+import ctypes
 from tkinter import filedialog, messagebox, ttk
 
 from . import __version__
@@ -11,6 +12,26 @@ from .core import (
     get_active_presentation_info,
 )
 from .i18n import DEFAULT_LANGUAGE, get_translator
+
+
+def _enable_high_dpi_support():
+    if os.name != "nt":
+        return
+
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except Exception:
+        try:
+            ctypes.windll.user32.SetProcessDPIAware()
+        except Exception:
+            pass
+
+
+def _fit_window(root, *, min_width, min_height):
+    root.update_idletasks()
+    width = max(min_width, root.winfo_reqwidth() + 24)
+    height = max(min_height, root.winfo_reqheight() + 32)
+    root.geometry(f"{width}x{height}")
 
 
 def _apply_crop_preset(percent_var, margin_var, preset_type):
@@ -141,6 +162,7 @@ def _build_crop_settings(parent, *, no_crop, margin_size, percent_retain, use_un
 
 
 def main():
+    _enable_high_dpi_support()
     root = tk.Tk()
     default_path_map = {}
 
@@ -154,7 +176,7 @@ def main():
     show_advanced = tk.BooleanVar(value=False)
 
     root.attributes("-topmost", True)
-    root.geometry("360x130")
+    root.geometry("400x160")
     root.resizable(False, False)
 
     main_frame = tk.Frame(root)
@@ -235,10 +257,10 @@ def main():
     def toggle_advanced():
         if show_advanced.get():
             advanced_frame.pack(fill=tk.BOTH, expand=True, pady=(5, 0))
-            root.geometry("390x410")
+            _fit_window(root, min_width=440, min_height=460)
         else:
             advanced_frame.pack_forget()
-            root.geometry("360x130")
+            _fit_window(root, min_width=400, min_height=160)
         update_texts()
 
     def hello_callback():
@@ -296,6 +318,7 @@ def main():
 
     language_select.bind("<<ComboboxSelected>>", lambda _event: update_texts())
     update_texts()
+    _fit_window(root, min_width=400, min_height=160)
     root.mainloop()
 
 

--- a/ppt2fig/gui.py
+++ b/ppt2fig/gui.py
@@ -34,6 +34,16 @@ def _fit_window(root, *, min_width, min_height):
     root.geometry(f"{width}x{height}")
 
 
+def _quick_gui_min_size(lang, show_advanced):
+    if show_advanced:
+        if lang == "en":
+            return 620, 520
+        return 440, 460
+    if lang == "en":
+        return 520, 180
+    return 400, 160
+
+
 def _apply_crop_preset(percent_var, margin_var, preset_type):
     if preset_type == "tight":
         percent_var.set(0)
@@ -176,7 +186,8 @@ def main():
     show_advanced = tk.BooleanVar(value=False)
 
     root.attributes("-topmost", True)
-    root.geometry("400x160")
+    initial_width, initial_height = _quick_gui_min_size(DEFAULT_LANGUAGE, False)
+    root.geometry(f"{initial_width}x{initial_height}")
     root.resizable(False, False)
 
     main_frame = tk.Frame(root)
@@ -243,6 +254,7 @@ def main():
 
     def update_texts():
         current = translator()
+        min_width, min_height = _quick_gui_min_size(language_var.get(), show_advanced.get())
         root.title(current("gui.quick.title", version=__version__))
         language_label.config(text=current("lang.label"))
         convert_button.config(text=current("gui.quick.export_button"))
@@ -253,14 +265,13 @@ def main():
         )
         for widget, key in advanced_text_widgets.values():
             widget.config(text=current(key))
+        _fit_window(root, min_width=min_width, min_height=min_height)
 
     def toggle_advanced():
         if show_advanced.get():
             advanced_frame.pack(fill=tk.BOTH, expand=True, pady=(5, 0))
-            _fit_window(root, min_width=440, min_height=460)
         else:
             advanced_frame.pack_forget()
-            _fit_window(root, min_width=400, min_height=160)
         update_texts()
 
     def hello_callback():
@@ -318,7 +329,7 @@ def main():
 
     language_select.bind("<<ComboboxSelected>>", lambda _event: update_texts())
     update_texts()
-    _fit_window(root, min_width=400, min_height=160)
+    _fit_window(root, min_width=initial_width, min_height=initial_height)
     root.mainloop()
 
 

--- a/ppt2fig/i18n.py
+++ b/ppt2fig/i18n.py
@@ -1,0 +1,313 @@
+import argparse
+from dataclasses import dataclass
+
+
+DEFAULT_LANGUAGE = "zh"
+SUPPORTED_LANGUAGES = ("zh", "en")
+
+
+MESSAGES = {
+    "lang.label": {"zh": "语言", "en": "Language"},
+    "lang.help": {"zh": "界面/命令行语言，默认 zh", "en": "UI/CLI language, default: zh"},
+    "lang.option.zh": {"zh": "中文", "en": "Chinese"},
+    "lang.option.en": {"zh": "英文", "en": "English"},
+    "common.success": {"zh": "成功", "en": "Success"},
+    "common.error": {"zh": "错误", "en": "Error"},
+    "common.browse": {"zh": "浏览", "en": "Browse"},
+    "common.refresh": {"zh": "刷新", "en": "Refresh"},
+    "common.load": {"zh": "载入", "en": "Load"},
+    "common.delete": {"zh": "删除", "en": "Delete"},
+    "common.filetype.presentation": {"zh": "演示文稿", "en": "Presentation"},
+    "common.filetype.all_files": {"zh": "所有文件", "en": "All files"},
+    "common.filetype.pdf": {"zh": "PDF 文件", "en": "PDF file"},
+    "cli.description": {
+        "zh": "将指定 PPTX 的指定页导出为 PDF，并可选自动裁剪白边。",
+        "en": "Export selected pages from a presentation to PDF, with optional automatic whitespace cropping.",
+    },
+    "cli.arg.pptx": {"zh": "输入的 PPTX 文件路径", "en": "Input presentation path"},
+    "cli.arg.pages": {
+        "zh": "要导出的页码，支持 1,3,5-7 这种格式，页码从 1 开始",
+        "en": "Pages to export, such as 1,3,5-7. Page numbers start at 1.",
+    },
+    "cli.arg.output": {
+        "zh": "输出 PDF 路径，默认在输入文件同目录下生成",
+        "en": "Output PDF path. Defaults to the input file directory.",
+    },
+    "cli.arg.office_bin": {
+        "zh": "手动指定导出后端可执行文件路径，例如 soffice 或 libreoffice",
+        "en": "Manually specify the export backend executable, such as soffice or libreoffice.",
+    },
+    "cli.arg.backend": {
+        "zh": "选择导出后端，默认 auto",
+        "en": "Select the export backend. Default: auto.",
+    },
+    "cli.arg.list_backends": {
+        "zh": "列出当前系统检测到的候选后端并退出",
+        "en": "List detected backend candidates on this system and exit.",
+    },
+    "cli.arg.powerpoint_intent": {
+        "zh": "PowerPoint 后端的导出意图，默认 print",
+        "en": "PowerPoint export intent. Default: print.",
+    },
+    "cli.arg.bitmap_missing_fonts": {
+        "zh": "PowerPoint 后端在字体无法嵌入时将文字位图化",
+        "en": "Rasterize text when PowerPoint cannot embed fonts.",
+    },
+    "cli.arg.no_crop": {"zh": "导出后不裁剪白边", "en": "Do not crop whitespace after export."},
+    "cli.arg.percent_retain": {
+        "zh": "保留原始边距的百分比，默认 0",
+        "en": "Percentage of the original margins to retain. Default: 0.",
+    },
+    "cli.arg.margin_size": {
+        "zh": "裁剪后额外增加的白边，单位 bp，默认 0",
+        "en": "Extra margin to add after cropping, in bp. Default: 0.",
+    },
+    "cli.arg.threshold": {
+        "zh": "背景检测阈值，默认 191",
+        "en": "Background detection threshold. Default: 191.",
+    },
+    "cli.arg.no_uniform": {"zh": "禁用统一裁剪", "en": "Disable uniform cropping."},
+    "cli.arg.no_same_size": {"zh": "禁用统一页面大小", "en": "Disable same-size pages."},
+    "cli.error.missing_pptx": {"zh": "缺少输入文件 pptx", "en": "missing input file: pptx"},
+    "cli.error.missing_pages": {"zh": "缺少必填参数: -p/--pages", "en": "missing required argument: -p/--pages"},
+    "cli.error.prefix": {"zh": "错误", "en": "error"},
+    "cli.error.input_not_found": {"zh": "输入文件不存在: {path}", "en": "input file does not exist: {path}"},
+    "cli.error.invalid_extension": {
+        "zh": "输入文件必须是 .pptx、.ppt 或 .odp",
+        "en": "input file must be .pptx, .ppt, or .odp",
+    },
+    "cli.list_backends.none": {"zh": "未检测到任何候选后端", "en": "No backend candidates detected."},
+    "cli.backend.supported": {"zh": "已支持", "en": "supported"},
+    "cli.backend.detected": {"zh": "已检测", "en": "detected"},
+    "core.error.missing_pdfcropmargins": {
+        "zh": "当前环境缺少 pdfCropMargins，无法执行 PDF 裁剪",
+        "en": "pdfCropMargins is not installed in the current environment, so PDF cropping is unavailable.",
+    },
+    "core.error.page_empty": {"zh": "页码不能为空", "en": "page specification cannot be empty"},
+    "core.error.page_must_start_1": {"zh": "页码必须从 1 开始", "en": "page numbers must start at 1"},
+    "core.error.invalid_page_range": {"zh": "无效页码范围: {part}", "en": "invalid page range: {part}"},
+    "core.error.invalid_page_token": {"zh": "无效页码值: {value}", "en": "invalid page value: {value}"},
+    "core.error.no_valid_pages": {"zh": "没有解析出有效页码", "en": "no valid pages were parsed"},
+    "core.error.missing_pypdf": {
+        "zh": "当前环境缺少 pypdf，无法抽取指定页",
+        "en": "pypdf is not installed in the current environment, so selected pages cannot be extracted.",
+    },
+    "core.error.page_out_of_range": {
+        "zh": "请求的页码 {page_number} 超出范围，导出的 PDF 只有 {total_pages} 页",
+        "en": "requested page {page_number} is out of range; the exported PDF only has {total_pages} pages",
+    },
+    "core.detail.missing_comtypes": {"zh": "当前环境缺少 comtypes", "en": "comtypes is not installed in the current environment"},
+    "core.detail.com_unavailable": {"zh": "COM 不可用: {error}", "en": "COM is unavailable: {error}"},
+    "core.detail.com_available": {"zh": "COM 可用: {value}", "en": "COM is available: {value}"},
+    "core.detail.powerpoint_not_detected_mac": {
+        "zh": "未检测到 Microsoft PowerPoint.app",
+        "en": "Microsoft PowerPoint.app was not detected",
+    },
+    "core.detail.powerpoint_applescript": {"zh": "可通过 AppleScript 驱动", "en": "driven through AppleScript"},
+    "core.detail.powerpoint_cli_not_supported": {
+        "zh": "当前系统不支持 PowerPoint CLI 导出",
+        "en": "PowerPoint CLI export is not supported on this system",
+    },
+    "core.detail.wps_binary_not_detected": {
+        "zh": "未检测到 WPS 可执行文件",
+        "en": "no WPS executable was detected",
+    },
+    "core.detail.wps_com_progid_not_found": {
+        "zh": "未找到 WPS Presentation COM ProgID",
+        "en": "no WPS Presentation COM ProgID was found",
+    },
+    "core.detail.wps_mac_not_implemented": {
+        "zh": "已检测到 WPS.app，但当前还未实现 macOS 自动导出",
+        "en": "WPS.app was detected, but automatic export on macOS is not implemented yet",
+    },
+    "core.detail.wps_app_not_detected": {"zh": "未检测到 WPS.app", "en": "WPS.app was not detected"},
+    "core.detail.wps_platform_not_implemented": {
+        "zh": "已检测到 WPS 可执行文件，但当前还未实现该平台自动导出",
+        "en": "a WPS executable was detected, but automatic export on this platform is not implemented yet",
+    },
+    "core.detail.wps_candidate_detected": {"zh": "已检测到 WPS 候选程序", "en": "WPS candidate detected"},
+    "core.detail.explicit_office_bin": {"zh": "通过 --office-bin 指定", "en": "specified via --office-bin"},
+    "core.detail.powerpoint_candidate_detected": {
+        "zh": "已检测到 PowerPoint 候选程序",
+        "en": "PowerPoint candidate detected",
+    },
+    "core.error.backend_not_found": {
+        "zh": "未找到可用的导出后端。请求后端: {backend}。已检测到: {detected_names}。当前已实现的自动导出后端: LibreOffice、PowerPoint(Windows/macOS)、WPS(Windows)。",
+        "en": "No usable export backend was found. Requested backend: {backend}. Detected: {detected_names}. Automatic export is currently implemented for LibreOffice, PowerPoint (Windows/macOS), and WPS (Windows).",
+    },
+    "core.error.libreoffice_export_failed_default": {"zh": "LibreOffice 导出失败", "en": "LibreOffice export failed"},
+    "core.error.libreoffice_pdf_missing": {
+        "zh": "LibreOffice 没有生成预期的 PDF 文件",
+        "en": "LibreOffice did not generate the expected PDF file",
+    },
+    "core.error.powerpoint_windows_only": {"zh": "PowerPoint 后端仅支持 Windows", "en": "the PowerPoint backend only supports Windows"},
+    "core.error.missing_comtypes_powerpoint": {
+        "zh": "当前环境缺少 comtypes，无法调用 PowerPoint",
+        "en": "comtypes is not installed in the current environment, so PowerPoint cannot be used.",
+    },
+    "core.error.powerpoint_export_failed": {"zh": "PowerPoint 导出失败: {error}", "en": "PowerPoint export failed: {error}"},
+    "core.error.powerpoint_pdf_missing": {
+        "zh": "PowerPoint 没有生成预期的 PDF 文件",
+        "en": "PowerPoint did not generate the expected PDF file",
+    },
+    "core.error.wps_windows_only": {"zh": "WPS 后端仅支持 Windows", "en": "the WPS backend only supports Windows"},
+    "core.error.missing_comtypes_wps": {
+        "zh": "当前环境缺少 comtypes，无法调用 WPS",
+        "en": "comtypes is not installed in the current environment, so WPS cannot be used.",
+    },
+    "core.error.wps_com_missing": {
+        "zh": "未找到可用的 WPS Presentation COM 接口",
+        "en": "no usable WPS Presentation COM interface was found",
+    },
+    "core.error.wps_export_failed_both": {
+        "zh": "WPS 导出失败。ExportAsFixedFormat 错误: {fixed_error}; SaveAs(PDF) 错误: {save_error}",
+        "en": "WPS export failed. ExportAsFixedFormat error: {fixed_error}; SaveAs(PDF) error: {save_error}",
+    },
+    "core.error.wps_export_failed": {"zh": "WPS 导出失败: {error}", "en": "WPS export failed: {error}"},
+    "core.error.wps_pdf_missing": {"zh": "WPS 没有生成预期的 PDF 文件", "en": "WPS did not generate the expected PDF file"},
+    "core.error.backend_unsupported": {
+        "zh": "暂不支持使用后端 {backend} 导出",
+        "en": "export with backend {backend} is not supported yet",
+    },
+    "core.error.active_powerpoint_not_running": {"zh": "PowerPoint未启动", "en": "PowerPoint is not running"},
+    "core.error.active_powerpoint_no_file": {"zh": "没有打开的PPT文件", "en": "no presentation is open in PowerPoint"},
+    "core.error.conversion_failed": {"zh": "转换过程出错", "en": "the conversion process failed"},
+    "core.error.active_presentation_missing": {
+        "zh": "PowerPoint未启动或没有打开的文件",
+        "en": "PowerPoint is not running or no presentation is open",
+    },
+    "core.error.active_presentation_info_failed": {"zh": "无法获取PPT文件信息", "en": "unable to get presentation file information"},
+    "gui.crop.title": {"zh": "PDF裁剪参数设置", "en": "PDF Crop Settings"},
+    "gui.crop.quick": {"zh": "快速设置", "en": "Quick Presets"},
+    "gui.crop.detail": {"zh": "详细参数", "en": "Detailed Options"},
+    "gui.crop.preset.tight": {"zh": "紧密裁剪", "en": "Tight Crop"},
+    "gui.crop.preset.small_margin": {"zh": "小白边", "en": "Small Margin"},
+    "gui.crop.preset.medium_margin": {"zh": "中白边", "en": "Medium Margin"},
+    "gui.crop.preset.keep_original": {"zh": "保留原边距", "en": "Keep Original Margin"},
+    "gui.crop.percent": {"zh": "保留原始边距(%):", "en": "Retain Original Margin (%):"},
+    "gui.crop.margin": {"zh": "额外白边(bp):", "en": "Extra Margin (bp):"},
+    "gui.crop.threshold": {"zh": "检测阈值:", "en": "Threshold:"},
+    "gui.crop.no_crop": {"zh": "不裁剪", "en": "No Crop"},
+    "gui.crop.uniform": {"zh": "统一裁剪", "en": "Uniform Crop"},
+    "gui.crop.same_size": {"zh": "统一页面大小", "en": "Same Page Size"},
+    "gui.quick.title": {"zh": "PPT转PDF工具 v{version}", "en": "PPT to PDF Tool v{version}"},
+    "gui.quick.export_button": {"zh": "转PDF", "en": "Export PDF"},
+    "gui.quick.show_advanced": {"zh": "▼ 显示高级设置", "en": "▼ Show Advanced"},
+    "gui.quick.hide_advanced": {"zh": "▲ 隐藏高级设置", "en": "▲ Hide Advanced"},
+    "gui.quick.success_message": {"zh": "PDF已导出至：\n{path}", "en": "PDF exported to:\n{path}"},
+    "gui.quick.convert_failed": {"zh": "转换失败", "en": "Conversion failed"},
+    "gui.quick.save_title": {"zh": "选择输出 PDF", "en": "Choose Output PDF"},
+    "gui.file.title": {"zh": "PPT2Fig 文件模式 v{version}", "en": "PPT2Fig File Mode v{version}"},
+    "gui.file.header_title": {"zh": "PPT2Fig 文件模式", "en": "PPT2Fig File Mode"},
+    "gui.file.header_subtitle": {
+        "zh": "面向重复导出场景：左侧保留最近任务，右侧编辑当前配置。",
+        "en": "Built for repeated exports: recent tasks stay on the left, and the active configuration is edited on the right.",
+    },
+    "gui.file.history_title": {"zh": "最近任务", "en": "Recent Tasks"},
+    "gui.file.history_subtitle": {
+        "zh": "双击可直接重导，单击后可载入到右侧编辑。",
+        "en": "Double-click to re-export immediately, or single-click to load the task into the editor.",
+    },
+    "gui.file.history_untitled": {"zh": "未命名", "en": "Untitled"},
+    "gui.file.history_label": {
+        "zh": "{prefix}{name} | 页码 {pages} | {backend}",
+        "en": "{prefix}{name} | Pages {pages} | {backend}",
+    },
+    "gui.file.history_rerun": {"zh": "重导", "en": "Re-export"},
+    "gui.file.current_title": {"zh": "当前配置", "en": "Current Configuration"},
+    "gui.file.choose_file": {"zh": "选择文件", "en": "Choose File"},
+    "gui.file.output_same_dir": {"zh": "输出同目录", "en": "Output Beside Source"},
+    "gui.file.refresh_backends": {"zh": "刷新后端", "en": "Refresh Backends"},
+    "gui.file.auto_output_name": {"zh": "自动生成输出文件名", "en": "Auto-generate Output Name"},
+    "gui.file.section_basic": {"zh": "基础信息", "en": "Basic Information"},
+    "gui.file.field_source": {"zh": "输入文件", "en": "Input File"},
+    "gui.file.field_pages": {"zh": "页码", "en": "Pages"},
+    "gui.file.pages_hint": {"zh": "支持 1,3,5-7", "en": "Supports 1,3,5-7"},
+    "gui.file.first_page": {"zh": "第一页", "en": "First Page"},
+    "gui.file.field_output": {"zh": "输出 PDF", "en": "Output PDF"},
+    "gui.file.section_backend": {"zh": "导出后端", "en": "Export Backend"},
+    "gui.file.field_backend": {"zh": "后端", "en": "Backend"},
+    "gui.file.field_program_path": {"zh": "程序路径", "en": "Program Path"},
+    "gui.file.field_detection_status": {"zh": "检测状态", "en": "Detection Status"},
+    "gui.file.section_powerpoint": {"zh": "PowerPoint 特定选项", "en": "PowerPoint Options"},
+    "gui.file.field_export_intent": {"zh": "导出意图", "en": "Export Intent"},
+    "gui.file.bitmap_missing_fonts": {"zh": "缺字库时将文字位图化", "en": "Rasterize text when fonts are missing"},
+    "gui.file.section_crop": {"zh": "裁剪与页面设置", "en": "Cropping and Page Settings"},
+    "gui.file.export_button": {"zh": "导出当前配置", "en": "Export Current Configuration"},
+    "gui.file.status.ready": {
+        "zh": "选择文件后即可导出，常用配置会自动进入左侧历史记录。",
+        "en": "Choose a file to start exporting. Frequent configurations are added to the history list automatically.",
+    },
+    "gui.file.status.loaded_history": {
+        "zh": "已载入历史任务，可直接修改后重新导出。",
+        "en": "The history task has been loaded. You can edit it and export again.",
+    },
+    "gui.file.status.deleted_history": {"zh": "已删除一条历史任务。", "en": "One history task was deleted."},
+    "gui.file.status.selected_file": {"zh": "已选择输入文件。", "en": "Input file selected."},
+    "gui.file.status.refreshed_backends": {"zh": "已刷新后端检测结果。", "en": "Backend detection results refreshed."},
+    "gui.file.status.export_failed": {"zh": "导出失败: {error}", "en": "Export failed: {error}"},
+    "gui.file.status.export_done": {"zh": "导出完成: {path}", "en": "Export completed: {path}"},
+    "gui.file.status.exporting": {"zh": "正在导出，请稍候...", "en": "Exporting. Please wait..."},
+    "gui.file.backend_none_detected": {"zh": "未检测到可用后端", "en": "No usable backends detected"},
+    "gui.file.dialog.select_input": {"zh": "选择输入文件", "en": "Choose Input File"},
+    "gui.file.dialog.select_output": {"zh": "选择输出 PDF", "en": "Choose Output PDF"},
+    "gui.file.dialog.select_backend_bin": {"zh": "选择后端可执行文件", "en": "Choose Backend Executable"},
+    "gui.file.error.select_input": {"zh": "请选择输入文件", "en": "please choose an input file"},
+    "gui.file.error.input_not_found": {"zh": "输入文件不存在", "en": "input file does not exist"},
+}
+
+
+ARGPARSE_TRANSLATIONS = {
+    "zh": {
+        "positional arguments": "位置参数",
+        "options": "可选参数",
+        "show this help message and exit": "显示此帮助信息并退出",
+        "show program's version number and exit": "显示程序版本号并退出",
+        "usage: ": "用法: ",
+        "error: ": "错误: ",
+        "argument %(argument_name)s: %(message)s": "参数 %(argument_name)s: %(message)s",
+        "the following arguments are required: %s": "缺少以下必填参数: %s",
+        "expected one argument": "需要一个参数值",
+        "invalid %(type)s value: %(value)r": "无效%(type)s值: %(value)r",
+        "invalid choice: %(value)r (choose from %(choices)s)": "无效选项: %(value)r（可选值: %(choices)s）",
+        "%(prog)s: error: %(message)s\n": "%(prog)s: 错误: %(message)s\n",
+    },
+    "en": {},
+}
+
+
+@dataclass(frozen=True)
+class Translator:
+    lang: str = DEFAULT_LANGUAGE
+
+    def __call__(self, key, **kwargs):
+        message = MESSAGES[key][self.lang]
+        return message.format(**kwargs)
+
+    tr = __call__
+
+
+def normalize_language(lang):
+    return lang if lang in SUPPORTED_LANGUAGES else DEFAULT_LANGUAGE
+
+
+def get_translator(lang=None):
+    return Translator(normalize_language(lang))
+
+
+def tr(key, *, lang=None, **kwargs):
+    return get_translator(lang)(key, **kwargs)
+
+
+def install_argparse_translations(lang):
+    translations = ARGPARSE_TRANSLATIONS.get(normalize_language(lang), {})
+
+    def gettext(message):
+        return translations.get(message, message)
+
+    def ngettext(singular, plural, count):
+        message = singular if count == 1 else plural
+        return gettext(message)
+
+    argparse._ = gettext
+    argparse.ngettext = ngettext

--- a/ppt2fig/main.py
+++ b/ppt2fig/main.py
@@ -1,6 +1,8 @@
 import platform
 import sys
 
+from .i18n import DEFAULT_LANGUAGE
+
 
 def main():
     if len(sys.argv) > 1:
@@ -17,7 +19,7 @@ def main():
 
     from .cli import build_parser
 
-    build_parser().print_help()
+    build_parser(DEFAULT_LANGUAGE).print_help()
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from ppt2fig import __version__
 
 setup(name='ppt2fig',
       version=__version__,
-      description='导出 PowerPoint 页面为 PDF，支持 Windows GUI 和跨平台 CLI。',
+      description='Export PowerPoint pages to PDF with Windows GUIs and a cross-platform CLI / 导出 PowerPoint 页面为 PDF，支持 Windows GUI 和跨平台 CLI。',
       long_description=open('README.md', encoding='utf-8').read(),
       long_description_content_type='text/markdown',
       author='Elliot Zheng',


### PR DESCRIPTION
## Summary
- add a lightweight shared i18n layer with Chinese as the default and English as an explicit option
- localize CLI help, parser errors, runtime messages, backend listing output, and both Tk GUIs
- add GUI language selectors and bilingual README/package metadata updates
- include Windows-tested file GUI fixes for error callbacks, export-state snapshotting, DPI awareness, and English layout sizing

## User-facing changes
- add `--lang {zh,en}` to the CLI, defaulting to `zh`
- keep backend ids and semantics unchanged: `auto`, `libreoffice`, `wps`, `powerpoint`, `print`, `screen`
- add visible language selectors to the quick GUI and file-mode GUI
- keep Chinese as the default language in all entry points

## Implementation notes
- use an in-repo dictionary-based translation catalog in `ppt2fig/i18n.py`
- propagate `lang` explicitly through CLI/core export paths instead of relying on hidden globals
- keep history storage keys unchanged and only localize the displayed labels in the file GUI

## Validation
- `python -m compileall ppt2fig`
- verified CLI `--help` in Chinese and English
- verified localized CLI error paths and backend listing output
- verified and fixed file-GUI issues found during Windows testing